### PR TITLE
Use body of delete

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
@@ -132,7 +132,7 @@ public abstract class HttpClient<T> {
             throw new RuntimeException(msg);
         }
         method = method.toUpperCase();
-        request.setMethod(method);        
+        request.setMethod(method);
         this.request = request;
         String url = request.getUrl();
         if (url == null) {
@@ -180,8 +180,11 @@ public abstract class HttpClient<T> {
                 return getEntity(request.getFormFields(), APPLICATION_FORM_URLENCODED);
             } else {
                 ScriptValue body = request.getBody();
-                if (body == null || body.isNull()) {
-                    String msg = "request body is requred for a " + method + ", please use the 'request' keyword";
+                if ((body == null || body.isNull()) && "DELETE".equals(method)) {
+                    logger.info("request body not provided and is not mandatory for " + method);
+                    return null;
+                } else if (body == null || body.isNull()) {
+                    String msg = "request body is required for a " + method + ", please use the 'request' keyword";
                     logger.error(msg);
                     throw new RuntimeException(msg);
                 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
@@ -169,7 +169,7 @@ public abstract class HttpClient<T> {
                 buildCookie(cookie);
             }
         }
-        if ("POST".equals(method) || "PUT".equals(method) || "PATCH".equals(method)) {
+        if ("POST".equals(method) || "PUT".equals(method) || "PATCH".equals(method) || "DELETE".equals(method)) {
             String mediaType = request.getContentType();
             if (request.getMultiPartItems() != null) {
                 if (mediaType == null) {


### PR DESCRIPTION
Hi Peter,
Following up on our discussion about the issue 'Unable to send a body with DELETE method', I am submitting this pull request.
The code change has been done on the latest version of Karate - v0.3.1 - at the time of this writing.
I have tested the change with POST and DELETE methods and it works as expected. POST method without body throws the Runtime exception but DELETE works with/without the request body.
Kindly let me know if you have any further comments/questions on the change.

Thanks.
Satish Autade