### PR TITLE
apache https client cert auth

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -130,8 +130,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     sslContext = SSLContexts.custom()
                             .useProtocol(algorithm) // will default to TLS if null
                             .loadTrustMaterial(trustStore, new TrustSelfSignedStrategy())
-                            // .loadKeyMaterial(keyStore, passwordChars).build();
-                            .build();
+                            .loadKeyMaterial(trustStore, passwordChars).build();
                 } catch (Exception e) {
                     context.logger.error("ssl config failed: {}", e.getMessage());
                     throw new RuntimeException(e);

--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -60,7 +60,6 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
@@ -129,7 +128,6 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     context.logger.debug("trust store key count: {}", trustStore.size());
                     sslContext = SSLContexts.custom()
                             .useProtocol(algorithm) // will default to TLS if null
-                            .loadTrustMaterial(trustStore, new TrustSelfSignedStrategy())
                             .loadKeyMaterial(trustStore, passwordChars).build();
                 } catch (Exception e) {
                     context.logger.error("ssl config failed: {}", e.getMessage());


### PR DESCRIPTION
Not much to it.  It could be worth it to keep LoadTrustMaterial and bump the apache http client version to 4.5.4 and use TrustAllStrategy--that should make sure it always works for everyone.  