### PR TITLE
Karate develop 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,6 +1514,7 @@ You can adjust configuration settings for the HTTP client used by Karate using t
 `afterFeature` | JS function | Will be called [after every `Feature`](#hooks), refer to this example: [`hooks.feature`](karate-demo/src/test/java/demo/hooks/hooks.feature)
 `ssl` | boolean | Enable HTTPS calls without needing to configure a trusted certificate or key-store.
 `ssl` | string | Like above, but force the SSL algorithm to one of [these values](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext). (The above form internally defaults to `TLS` if simply set to `true`).
+`ssl` | JSON | For X509 certificate authentication, set `keyStore`, `password`, `type`, and optionally `algorithm` (`algorithm` defaults to `TLS`).  See [X509 Certificate Authentication](#X509 Certificate Authentication)
 `followRedirects` | boolean | Whether the HTTP client automatically follows redirects - (default `true`), refer to this [example](karate-demo/src/test/java/demo/redirect/redirect.feature).
 `connectTimeout` | integer | Set the connect timeout (milliseconds). The default is 30000 (30 seconds).
 `readTimeout` | integer | Set the read timeout (milliseconds). The default is 30000 (30 seconds).
@@ -1535,6 +1536,9 @@ Examples:
 
 # enable ssl and force the algorithm to TLSv1.2
 * configure ssl = 'TLSv1.2'
+
+# enable X509 certificate authentication with PKCS12 file 'certstore.pfx' and password 'certpassword'
+* configure ssl = {keyStore: 'classpath:certstore.pfx', password: 'certpassword', type: 'pkcs12'};
 
 # time-out if the response is not received within 10 seconds (after the connection is established)
 * configure readTimeout = 10000
@@ -2843,6 +2847,16 @@ Once (or at the start of) every `Feature` | Use a [`callonce`](#callonce) in the
 After every `Scenario` | [`configure afterScenario`](#configure) (see [example](karate-demo/src/test/java/demo/hooks/hooks.feature))
 At the end of the `Feature` | [`configure afterFeature`](#configure) (see [example](karate-demo/src/test/java/demo/hooks/hooks.feature))
 
+## X509 Certificate Authentication
+
+Sometimes called "mutual auth"--if your API requires that clients present an X509 certificate for authentication, Karate supports this via configuration parameters.  
+
+Syntax is covered in [configure](#configure).  Note:
+
+* Allowed keystore types are as described in the [Sun Java KeyStore Docs](https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyStore)
+* Your keystore must contain the private key for your certificate
+* There is no need to provide a list of trusted certificates or CAs in the keystore (your keystore may require a root certificate for your client certificate, but Karate doesn't care about it)
+* Karate does not verify the server's certificate is trusted--all certificates are trusted, including self-signed certificates
 
 ## Data Driven Tests
 ### The Cucumber Way

--- a/README.md
+++ b/README.md
@@ -1514,7 +1514,7 @@ You can adjust configuration settings for the HTTP client used by Karate using t
 `afterFeature` | JS function | Will be called [after every `Feature`](#hooks), refer to this example: [`hooks.feature`](karate-demo/src/test/java/demo/hooks/hooks.feature)
 `ssl` | boolean | Enable HTTPS calls without needing to configure a trusted certificate or key-store.
 `ssl` | string | Like above, but force the SSL algorithm to one of [these values](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext). (The above form internally defaults to `TLS` if simply set to `true`).
-`ssl` | JSON | For X509 certificate authentication, set `keyStore`, `password`, `type`, and optionally `algorithm` (`algorithm` defaults to `TLS`).  See [X509 Certificate Authentication](#X509-Certificate-Authentication)
+`ssl` | JSON | For X509 certificate authentication, set `keyStore`, `password`, `type`, and optionally `algorithm` (`algorithm` defaults to `TLS`).  See [X509 Certificate Authentication](#x509-certificate-authentication)
 `followRedirects` | boolean | Whether the HTTP client automatically follows redirects - (default `true`), refer to this [example](karate-demo/src/test/java/demo/redirect/redirect.feature).
 `connectTimeout` | integer | Set the connect timeout (milliseconds). The default is 30000 (30 seconds).
 `readTimeout` | integer | Set the read timeout (milliseconds). The default is 30000 (30 seconds).

--- a/README.md
+++ b/README.md
@@ -1514,7 +1514,7 @@ You can adjust configuration settings for the HTTP client used by Karate using t
 `afterFeature` | JS function | Will be called [after every `Feature`](#hooks), refer to this example: [`hooks.feature`](karate-demo/src/test/java/demo/hooks/hooks.feature)
 `ssl` | boolean | Enable HTTPS calls without needing to configure a trusted certificate or key-store.
 `ssl` | string | Like above, but force the SSL algorithm to one of [these values](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext). (The above form internally defaults to `TLS` if simply set to `true`).
-`ssl` | JSON | For X509 certificate authentication, set `keyStore`, `password`, `type`, and optionally `algorithm` (`algorithm` defaults to `TLS`).  See [X509 Certificate Authentication](#X509 Certificate Authentication)
+`ssl` | JSON | For X509 certificate authentication, set `keyStore`, `password`, `type`, and optionally `algorithm` (`algorithm` defaults to `TLS`).  See [X509 Certificate Authentication](#X509-Certificate-Authentication)
 `followRedirects` | boolean | Whether the HTTP client automatically follows redirects - (default `true`), refer to this [example](karate-demo/src/test/java/demo/redirect/redirect.feature).
 `connectTimeout` | integer | Set the connect timeout (milliseconds). The default is 30000 (30 seconds).
 `readTimeout` | integer | Set the read timeout (milliseconds). The default is 30000 (30 seconds).

--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -130,7 +130,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     sslContext = SSLContexts.custom()
                             .setProtocol(algorithm) // will default to TLS if null
                             .loadTrustMaterial(trustStore, new TrustAllStrategy())
-                            // .loadKeyMaterial(keyStore, passwordChars).build();
+                            .loadKeyMaterial(trustStore, passwordChars)
                             .build();
                 } catch (Exception e) {
                     context.logger.error("ssl config failed: {}", e.getMessage());

--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -113,24 +113,24 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
         if (config.isSslEnabled()) {
             // System.setProperty("jsse.enableSNIExtension", "false");
             SSLContext sslContext;
-            if (config.getSslTrustStore() != null) {
-                String trustStoreFile = config.getSslTrustStore();                
-                String password = config.getSslTrustStorePassword();
+            if (config.getSslKeyStore() != null) {
+                String keyStoreFile = config.getSslKeyStore();
+                String password = config.getSslKeyStorePassword();
                 char[] passwordChars = password == null ? null : password.toCharArray();
                 String algorithm = config.getSslAlgorithm();
-                String type = config.getSslTrustStoreType();
+                String type = config.getSslKeyStoreType();
                 if (type == null) {
                     type = KeyStore.getDefaultType();
                 }
                 try {
-                    KeyStore trustStore = KeyStore.getInstance(type);
-                    InputStream is = FileUtils.getFileStream(trustStoreFile, context);
-                    trustStore.load(is, passwordChars);
-                    context.logger.debug("trust store key count: {}", trustStore.size());
+                    KeyStore keyStore = KeyStore.getInstance(type);
+                    InputStream is = FileUtils.getFileStream(keyStoreFile, context);
+                    keyStore.load(is, passwordChars);
+                    context.logger.debug("trust store key count: {}", keyStore.size());
                     sslContext = SSLContexts.custom()
                             .setProtocol(algorithm) // will default to TLS if null
-                            .loadTrustMaterial(trustStore, new TrustAllStrategy())
-                            .loadKeyMaterial(trustStore, passwordChars)
+                            .loadTrustMaterial(keyStore, new TrustAllStrategy())
+                            .loadKeyMaterial(keyStore, passwordChars)
                             .build();
                 } catch (Exception e) {
                     context.logger.error("ssl config failed: {}", e.getMessage());

--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -126,7 +126,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     KeyStore keyStore = KeyStore.getInstance(type);
                     InputStream is = FileUtils.getFileStream(keyStoreFile, context);
                     keyStore.load(is, passwordChars);
-                    context.logger.debug("trust store key count: {}", keyStore.size());
+                    context.logger.debug("key store key count: {}", keyStore.size());
                     sslContext = SSLContexts.custom()
                             .setProtocol(algorithm) // will default to TLS if null
                             .loadTrustMaterial(keyStore, new TrustAllStrategy())

--- a/karate-core/src/main/java/com/intuit/karate/ScriptContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptContext.java
@@ -231,9 +231,9 @@ public class ScriptContext {
             } else if (value.isMapLike()) {
                 config.setSslEnabled(true);
                 Map<String, Object> map = value.getAsMap();
-                config.setSslTrustStore((String) map.get("trustStore"));
-                config.setSslTrustStorePassword((String) map.get("password"));
-                config.setSslTrustStoreType((String) map.get("type"));
+                config.setSslKeyStore((String) map.get("keyStore"));
+                config.setSslKeyStorePassword((String) map.get("password"));
+                config.setSslKeyStoreType((String) map.get("type"));
                 config.setSslAlgorithm((String) map.get("algorithm"));                
             } else {
                 config.setSslEnabled(value.isBooleanTrue());

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpConfig.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpConfig.java
@@ -34,9 +34,9 @@ public class HttpConfig {
     
     private boolean sslEnabled = false;
     private String sslAlgorithm = "TLS";
-    private String sslTrustStore;
-    private String sslTrustStorePassword;
-    private String sslTrustStoreType;
+    private String sslKeyStore;
+    private String sslKeyStorePassword;
+    private String sslKeyStoreType;
     private boolean followRedirects = true;    
     private int readTimeout = 30000;
     private int connectTimeout = 30000;
@@ -62,9 +62,9 @@ public class HttpConfig {
     public HttpConfig(HttpConfig parent) {
         sslEnabled = parent.sslEnabled;
         sslAlgorithm = parent.sslAlgorithm;
-        sslTrustStore = parent.sslTrustStore;
-        sslTrustStorePassword = parent.sslTrustStorePassword;
-        sslTrustStoreType = parent.sslTrustStoreType;
+        sslKeyStore = parent.sslKeyStore;
+        sslKeyStorePassword = parent.sslKeyStorePassword;
+        sslKeyStoreType = parent.sslKeyStoreType;
         followRedirects = parent.followRedirects;        
         readTimeout = parent.readTimeout;
         connectTimeout = parent.connectTimeout;
@@ -101,27 +101,27 @@ public class HttpConfig {
     }
 
     public String getSslKeyStore() {
-        return sslTrustStore;
+        return sslKeyStore;
     }
 
-    public void setSslKeyStore(String sslTrustStore) {
-        this.sslTrustStore = sslTrustStore;
+    public void setSslKeyStore(String sslKeyStore) {
+        this.sslKeyStore = sslKeyStore;
     }
 
     public String getSslKeyStorePassword() {
-        return sslTrustStorePassword;
+        return sslKeyStorePassword;
     }
 
-    public void setSslKeyStorePassword(String sslTrustStorePassword) {
-        this.sslTrustStorePassword = sslTrustStorePassword;
+    public void setSslKeyStorePassword(String sslKeyStorePassword) {
+        this.sslKeyStorePassword = sslKeyStorePassword;
     }
 
     public String getSslKeyStoreType() {
-        return sslTrustStoreType;
+        return sslKeyStoreType;
     }
 
-    public void setSslKeyStoreType(String sslTrustStoreType) {
-        this.sslTrustStoreType = sslTrustStoreType;
+    public void setSslKeyStoreType(String sslKeyStoreType) {
+        this.sslKeyStoreType = sslKeyStoreType;
     }        
     
     public boolean isFollowRedirects() {

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpConfig.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpConfig.java
@@ -100,27 +100,27 @@ public class HttpConfig {
         this.sslAlgorithm = sslAlgorithm;
     }
 
-    public String getSslTrustStore() {
+    public String getSslKeyStore() {
         return sslTrustStore;
     }
 
-    public void setSslTrustStore(String sslTrustStore) {
+    public void setSslKeyStore(String sslTrustStore) {
         this.sslTrustStore = sslTrustStore;
     }
 
-    public String getSslTrustStorePassword() {
+    public String getSslKeyStorePassword() {
         return sslTrustStorePassword;
     }
 
-    public void setSslTrustStorePassword(String sslTrustStorePassword) {
+    public void setSslKeyStorePassword(String sslTrustStorePassword) {
         this.sslTrustStorePassword = sslTrustStorePassword;
     }
 
-    public String getSslTrustStoreType() {
+    public String getSslKeyStoreType() {
         return sslTrustStoreType;
     }
 
-    public void setSslTrustStoreType(String sslTrustStoreType) {
+    public void setSslKeyStoreType(String sslTrustStoreType) {
         this.sslTrustStoreType = sslTrustStoreType;
     }        
     

--- a/karate-demo/src/test/java/karate-config.js
+++ b/karate-demo/src/test/java/karate-config.js
@@ -20,7 +20,7 @@ function() {
     config.queueName = karate.properties['shipping.queue.name'];
     if (config.paymentServiceUrl.startsWith('https')) {
       if (config.queueName == 'DEMO.CONTRACT.SSL') {
-        karate.configure('ssl', { trustStore: 'classpath:keystore.p12', password: 'karate-mock', type: 'pkcs12' });
+        karate.configure('ssl', { keyStore: 'classpath:keystore.p12', password: 'karate-mock', type: 'pkcs12' });
       } else {
         karate.configure('ssl', true);
       }

--- a/karate-jersey/src/main/java/com/intuit/karate/http/jersey/JerseyHttpClient.java
+++ b/karate-jersey/src/main/java/com/intuit/karate/http/jersey/JerseyHttpClient.java
@@ -83,24 +83,24 @@ public class JerseyHttpClient extends HttpClient<Entity> {
                 .register(MultiPartFeature.class);
         if (config.isSslEnabled()) {
             SSLContext sslContext;
-            if (config.getSslTrustStore() != null) {
-                String trustStoreFile = config.getSslTrustStore();                
-                String password = config.getSslTrustStorePassword();
+            if (config.getSslKeyStore() != null) {
+                String keyStoreFile = config.getSslKeyStore();
+                String password = config.getSslKeyStorePassword();
                 char[] passwordChars = password == null ? null : password.toCharArray();
                 String algorithm = config.getSslAlgorithm();
-                String type = config.getSslTrustStoreType();
+                String type = config.getSslKeyStoreType();
                 if (type == null) {
                     type = KeyStore.getDefaultType();
                 }
                 try {
-                    KeyStore trustStore = KeyStore.getInstance(type);
-                    InputStream is = FileUtils.getFileStream(trustStoreFile, context);
-                    trustStore.load(is, passwordChars);
-                    context.logger.debug("trust store key count: {}", trustStore.size());
+                    KeyStore keyStore = KeyStore.getInstance(type);
+                    InputStream is = FileUtils.getFileStream(keyStoreFile, context);
+                    keyStore.load(is, passwordChars);
+                    context.logger.debug("trust store key count: {}", keyStore.size());
                     sslContext = SslConfigurator.newInstance()
                             .securityProtocol(algorithm) // will default to TLS if null
-                            .trustStore(trustStore)
-                            // .keyStore(trustStore)
+                            .keyStore(keyStore)
+                            // .keyStore(keyStore)
                             .createSSLContext();
                 } catch (Exception e) {
                     context.logger.error("ssl config failed: {}", e.getMessage());

--- a/karate-jersey/src/test/java/ssl/ssl.feature
+++ b/karate-jersey/src/test/java/ssl/ssl.feature
@@ -1,7 +1,7 @@
 Feature: jersey ssl with trust store / cert
 
 Background:
-    * configure ssl = { trustStore: 'classpath:keystore.p12', password: 'karate-mock', type: 'pkcs12' }
+    * configure ssl = { keyStore: 'classpath:keystore.p12', password: 'karate-mock', type: 'pkcs12' }
     * url 'https://localhost:' + karate.properties['jersey.ssl.port']
 
 Scenario:


### PR DESCRIPTION
(started with reverting the last commit in develop)

- Eliminated truststore parameters since we're using trustallstrategy and the trust store doesn't matter.  
- Refactored trustStore to keyStore
- Added documentation of new parameters and errata

