### PR TITLE
Adds support for accordion-view of raw logs

### DIFF
--- a/karate-core/src/main/resources/report-template.html
+++ b/karate-core/src/main/resources/report-template.html
@@ -31,8 +31,10 @@
   .sidenav a:hover { color: #fff !important; } 
   .panel { position: relative; left: 5px; width: 20px !important; font-weight: 200; } 
   .scenario { margin-left: 300px; padding: 0px 10px; } 
+  .accordion { color: blue !important; font-weight: 800; cursor: pointer; transition: 0.4s; text-decoration: underline blue; }
+  .accordion_panel { display: none; }
   @media screen and (max-height: 450px) { 
-    .sidenav { padding-top: 15px; }                                            
+    .sidenav { padding-top: 15px; }                                       
     .sidenav a { font-size: 18px; } 
   }
 </style>
@@ -40,4 +42,3 @@
 <body>
 </body>
 </html>
-

--- a/karate-core/src/main/resources/report-template.js
+++ b/karate-core/src/main/resources/report-template.js
@@ -23,8 +23,8 @@ window.onload = function() {
     buildSidebarAnchors(mode);
     sidenavDiv.appendChild(modeBorder[mode]);
   }
-  console.log(tests);
-  console.log(modeBorder);
+  buildAccordians();
+
   function getIdForTest(i) {
     return('test_'+(i+1));
   }
@@ -53,5 +53,30 @@ window.onload = function() {
       }
     }
     modeBorder[mode].appendChild(document.createElement('br'));
+  }
+  function buildAccordians(){
+    tables = document.getElementsByTagName('table');
+    preformatted = document.getElementsByClassName('preformatted');
+    buildAccordianForListOfItems(tables);
+    buildAccordianForListOfItems(preformatted);
+    accordion = document.getElementsByClassName("accordion");
+    for (i = 0; i < accordion.length; i++) {
+        accordion[i].addEventListener("click", function() {
+            this.classList.toggle("active");
+            var panel = this.nextElementSibling;
+            if (panel.style.display === "block") {
+                panel.style.display = "none";
+            } else {
+                panel.style.display = "block";
+            }
+        });
+    }   
+    function buildAccordianForListOfItems(items) {
+      for(i=0;i<items.length;++i){
+        items[i].classList.add('accordion_panel');
+        step = items[i].previousElementSibling;
+        step.classList.add('accordion');
+      }      
+    }
   }
 }


### PR DESCRIPTION
This PR is the continuation of PR #316, to resolve #311. A sample screenshot of the existing changes has been attached below. All logs are collapsed by default, and can be triggered by pressing the respective "blue-colored" test.

![image](https://user-images.githubusercontent.com/17109060/36038580-16638244-0de6-11e8-91d5-963db400275f.png)