### PR TITLE
Adds markdown files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contribution guidelines
+
+First of all, thanks for thinking of contributing to this project. :smile:
+
+- Before sending a Pull Request, please make sure that you're assigned the  GitHub issue.
+    - If a relevant issue already exists, discuss on the issue and get it assigned to yourself on GitHub.
+    - If no relevant issue exists, open a new issue and get it assigned to yourself on GitHub.
+
+    Please proceed with a Pull Request only after you're assigned. It'd be sad if your Pull Request (and your hardwork) isn't accepted just because it isn't ideologically compatible.
+
+- Install the required dependencies.
+    - Install Git so that you can clone and later submit a PR for this project.
+    - Install Java JDK (>= 1.8.0_112) installed, from [this link](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+    - Install Eclipse from [this link](http://www.eclipse.org/downloads/).
+    - (optional) Install Maven from [this link](http://maven.apache.org), if you need to build the project from the command-line.
+
+- Have some issue with setting up the project?
+    - [How to open the project in Eclipse as a Maven project?](https://stackoverflow.com/a/36242422/143475)
+    - [Maven is not able to install the dependencies behind proxy!]()
+    - Not listed here? Kindly search on Google / Stack Overflow. If you don't find a solution, feel free to open up a new issue in the issue tracker and maybe subsequently add it here.
+
+- Send in your Pull Request(s) to the `develop` branch of this repository.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### Description
+
+Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.
+
+- Relevant Issues : (compulsory)
+- Relevant PRs : (optional)
+- Type of change :
+  - [ ] New feature
+  - [ ] Bug fix for existing feature
+  - [ ] Code quality improvement
+  - [ ] Addition or Improvement of tests
+  - [ ] Addition or Improvement of documentation


### PR DESCRIPTION
@ptrthomas - As discussed in #304, I've added initial drafts of `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md`. Feel free to suggest any changes that you've in mind. 😄 

Meanwhile, there are some well-recognized templates available for `CODE_OF_CONDUCT.md`. Amonst [these templates](http://todogroup.org/opencodeofconduct/), GitHub seems to promote "Contributor Covenant" by default. If you have selected a particular code of conduct for Karate, we could include it in this PR itself. Else, we can anyway add this in another PR later.