### PR TITLE
trust store fixes

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -124,7 +124,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
             try {
                 SSLContextBuilder builder = SSLContexts.custom()
                         .setProtocol(algorithm); // will default to TLS if null
-                if (trustStore == null) {
+                if (trustStore == null && config.isSslTrustAll() ) {
                     builder = builder.loadTrustMaterial(new TrustAllStrategy());
                 } else {
                     if (config.isSslTrustAll()) {

--- a/karate-core/src/main/java/com/intuit/karate/ScriptContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptContext.java
@@ -245,7 +245,7 @@ public class ScriptContext {
                 config.setSslTrustStore((String) map.get("trustStore"));
                 config.setSslTrustStorePassword((String) map.get("trustStorePassword"));
                 config.setSslTrustStoreType((String) map.get("trustStoreType"));
-                String trustAll = (String) map.get("trustStoreType");
+                String trustAll = (String) map.get("trustAll");
                 if (trustAll != null) {
                     config.setSslTrustAll(Boolean.valueOf(trustAll));
                 }


### PR DESCRIPTION
fix cut and paste bug in scriptcontext (I think--it's possible the intent was to only process this directive if trustStoreType is set, but that seems like an odd dependency)

fix logic for trustall and truststore so if trustAll is false and no trustStore is defined
we'll actually get the system trust store instead of trustallstrategy.  The current
behavior is trustAll=false only has an effect if you define a trustStore.  

Related to #281 

### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : trustall flag not quite working
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ XX ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
