### PR TITLE
Karate ui/directory panel

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/ui/App.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/App.java
@@ -28,6 +28,7 @@ import com.intuit.karate.ScriptBindings;
 import com.intuit.karate.convert.ConvertUtils;
 import com.intuit.karate.convert.PostmanRequest;
 import javafx.application.Application;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.layout.BorderPane;
@@ -44,7 +45,9 @@ import java.util.List;
  * @author pthomas3
  */
 public class App extends Application {
-    
+    public static final double PADDING = 3.0;
+    public static final Insets PADDING_INSET = new Insets(App.PADDING, App.PADDING, App.PADDING, App.PADDING);
+
     private final FileChooser fileChooser = new FileChooser();
     
     private File workingDir = new File(".");

--- a/karate-core/src/main/java/com/intuit/karate/ui/DirectoryPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/DirectoryPanel.java
@@ -17,9 +17,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public class DirectoryPanel extends ScrollPane {
+import static com.intuit.karate.ui.App.PADDING_INSET;
+
+public class DirectoryPanel extends BorderPane {
 
     private final TreeView<String> treeView = new TreeView<String>();
+    private final ScrollPane scrollPane = new ScrollPane();
     private final App app ;
     private final String envString ;
     private final Stage stage;
@@ -57,7 +60,7 @@ public class DirectoryPanel extends ScrollPane {
     }
 
     public void init(File choice) {
-        BorderPane borderPane = new BorderPane();
+        this.setPadding(PADDING_INSET);
         treeView.setRoot(getNodesForDirectory(choice));
         treeView.addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventHandle);
 
@@ -73,9 +76,9 @@ public class DirectoryPanel extends ScrollPane {
                 }
         );
 
-        borderPane.setCenter(treeView);
-        setContent(borderPane);
-        setFitToWidth(true);
+        scrollPane.setContent(treeView);
+        this.setCenter(scrollPane);
+        scrollPane.setFitToWidth(true);
     }
 
     public TreeItem<String> getNodesForDirectory(File directory) {

--- a/karate-core/src/main/java/com/intuit/karate/ui/DragResizer.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/DragResizer.java
@@ -1,0 +1,362 @@
+package com.intuit.karate.ui;
+
+import javafx.event.EventHandler;
+import javafx.scene.Cursor;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Region;
+
+/**
+ * {@link DragResizer} can be used to add mouse listeners to a {@link Region}
+ * and make it moveable and resizable by the user by clicking and dragging the
+ * border in the same way as a window, or clicking within the window to move it
+ * around.
+ * <p>
+ * Height and width resizing is implemented, from the sides and corners.
+ * Dragging of the region is also optionally available, and the movement and
+ * resizing can be constrained within the bounds of the parent.
+ * <p>
+ * Usage:
+ * <pre>DragResizer.makeResizable(myAnchorPane, true, true, true, true);</pre> makes the
+ * region resizable for hight and width and moveable, but only within the bounds of the parent.
+ * <p>
+ * Builds on the modifications to theoriginal version by
+ * Geoff Capper.
+ * <p>
+ *
+ */
+public class DragResizer {
+
+    /**
+     * Enum containing the zones that we can drag around.
+     */
+    enum Zone {
+        NONE, N, NE, E, SE, S, SW, W, NW, C
+    }
+
+    /**
+     * The margin around the control that a user can click in to start resizing
+     * the region.
+     */
+    private  final int RESIZE_MARGIN = 5;
+
+    /**
+     * How small can we go?
+     */
+    private  final int MIN_SIZE = 10;
+
+    private Region region;
+
+    private double y;
+
+    private double x;
+
+    private boolean initMinHeight;
+
+    private boolean initMinWidth;
+
+    private Zone zone;
+
+    private boolean dragging;
+
+    /**
+     * Whether the sizing and movement of the region is constrained within the
+     * bounds of the parent.
+     */
+    private boolean constrainToParent;
+
+    /**
+     * Whether dragging of the region is allowed.
+     */
+    private boolean allowMove;
+
+    /**
+     * Whether resizing of height is allowed.
+     */
+    private boolean allowHeightResize;
+
+    /**
+     * Whether resizing of width is allowed.
+     */
+    private boolean allowWidthResize;
+
+    private DragResizer(Region aRegion, boolean allowMove, boolean constrainToParent, boolean allowHeightResize, boolean allowWidthResize) {
+        region = aRegion;
+        this.constrainToParent = constrainToParent;
+        this.allowMove = allowMove;
+        this.allowHeightResize = allowHeightResize;
+        this.allowWidthResize = allowWidthResize;
+    }
+
+
+    /**
+     * Makes the region resizable, and optionally moveable, and constrained
+     * within the bounds of the parent.
+     *
+     * @param region
+     * @param allowMove Allow a click in the centre of the region to start
+     * dragging it around.
+     * @param constrainToParent Prevent movement and/or resizing outside the
+     * @param allowHeightResize if set to true makes component height resizeAble
+     * @param allowWidthResize if set to true makes component width resizeAble
+     * parent.
+     */
+    public static void makeResizable(Region region, boolean allowMove, boolean constrainToParent, boolean allowHeightResize, boolean allowWidthResize) {
+        final DragResizer resizer = new DragResizer(region, allowMove, constrainToParent, allowHeightResize, allowWidthResize);
+
+        region.setOnMousePressed(new EventHandler<MouseEvent>() {
+            @Override
+            public void handle(MouseEvent event) {
+                resizer.mousePressed(event);
+            }
+        });
+        region.setOnMouseDragged(new EventHandler<MouseEvent>() {
+            @Override
+            public void handle(MouseEvent event) {
+                resizer.mouseDragged(event);
+            }
+        });
+        region.setOnMouseMoved(new EventHandler<MouseEvent>() {
+            @Override
+            public void handle(MouseEvent event) {
+                resizer.mouseOver(event);
+            }
+        });
+        region.setOnMouseReleased(new EventHandler<MouseEvent>() {
+            @Override
+            public void handle(MouseEvent event) {
+                resizer.mouseReleased(event);
+            }
+        });
+    }
+
+    protected void mouseReleased(MouseEvent event) {
+        dragging = false;
+        region.setCursor(Cursor.DEFAULT);
+    }
+
+    protected void mouseOver(MouseEvent event) {
+        if (isInDraggableZone(event) || dragging) {
+            switch (zone) {
+                case N: {
+                    region.setCursor(Cursor.N_RESIZE);
+                    break;
+                }
+                case NE: {
+                    region.setCursor(Cursor.NE_RESIZE);
+                    break;
+                }
+                case E: {
+                    region.setCursor(Cursor.E_RESIZE);
+                    break;
+                }
+                case SE: {
+                    region.setCursor(Cursor.SE_RESIZE);
+                    break;
+                }
+                case S: {
+                    region.setCursor(Cursor.S_RESIZE);
+                    break;
+                }
+                case SW: {
+                    region.setCursor(Cursor.SW_RESIZE);
+                    break;
+                }
+                case W: {
+                    region.setCursor(Cursor.W_RESIZE);
+                    break;
+                }
+                case NW: {
+                    region.setCursor(Cursor.NW_RESIZE);
+                    break;
+                }
+                case C: {
+                    region.setCursor(Cursor.MOVE);
+                    break;
+                }
+            }
+
+        } else {
+            region.setCursor(Cursor.DEFAULT);
+        }
+    }
+
+    protected boolean isInDraggableZone(MouseEvent event) {
+        zone = Zone.NONE;
+        if(allowWidthResize) {
+            if ((event.getY() < RESIZE_MARGIN) && (event.getX() < RESIZE_MARGIN)) {
+                zone = Zone.NW;
+            } else if ((event.getY() < RESIZE_MARGIN) && (event.getX() > (region.getWidth() - RESIZE_MARGIN))) {
+                zone = Zone.NE;
+            } else if ((event.getY() > (region.getHeight() - RESIZE_MARGIN)) && (event.getX() > (region.getWidth() - RESIZE_MARGIN))) {
+                zone = Zone.SE;
+            } else if ((event.getY() > (region.getHeight() - RESIZE_MARGIN)) && (event.getX() < RESIZE_MARGIN)) {
+                zone = Zone.SW;
+            } else if (event.getX() < RESIZE_MARGIN) {
+                zone = Zone.W;
+            } else if (event.getX() > (region.getWidth() - RESIZE_MARGIN)) {
+                zone = Zone.E;
+            }
+        } else if (allowHeightResize) {
+            if (event.getY() > (region.getHeight() - RESIZE_MARGIN)) {
+                zone = Zone.S;
+            } else if (event.getY() < RESIZE_MARGIN) {
+                zone = Zone.N;
+            }
+        } else if (allowMove) {
+                zone = Zone.C;
+        }
+        return !Zone.NONE.equals(zone);
+
+    }
+
+    protected void mouseDragged(MouseEvent event) {
+        if (!dragging) {
+            return;
+        }
+
+        double deltaY = allowHeightResize ? event.getSceneY() - y : 0;
+        double deltaX = allowWidthResize ? event.getSceneX() - x : 0;
+
+        double originY = region.getLayoutY();
+        double originX = region.getLayoutX();
+
+        double newHeight = region.getMinHeight();
+        double newWidth = region.getMinWidth();
+
+        switch (zone) {
+            case N: {
+                originY += deltaY;
+                newHeight -= deltaY;
+                break;
+            }
+            case NE: {
+                originY += deltaY;
+                newHeight -= deltaY;
+                newWidth += deltaX;
+                break;
+            }
+            case E: {
+                newWidth += deltaX;
+                break;
+            }
+            case SE: {
+                newHeight += deltaY;
+                newWidth += deltaX;
+                break;
+            }
+            case S: {
+                newHeight += deltaY;
+                break;
+            }
+            case SW: {
+                originX += deltaX;
+                newHeight += deltaY;
+                newWidth -= deltaX;
+                break;
+            }
+            case W: {
+                originX += deltaX;
+                newWidth -= deltaX;
+                break;
+            }
+            case NW: {
+                originY += deltaY;
+                originX += deltaX;
+                newWidth -= deltaX;
+                newHeight -= deltaY;
+                break;
+            }
+            case C: {
+                originY += deltaY;
+                originX += deltaX;
+                break;
+            }
+        }
+
+        if (constrainToParent) {
+
+            if (originX < 0) {
+                if (!Zone.C.equals(zone)) {
+                    newWidth -= Math.abs(originX);
+                }
+                originX = 0;
+            }
+            if (originY < 0) {
+                if (!Zone.C.equals(zone)) {
+                    newHeight -= Math.abs(originY);
+                }
+                originY = 0;
+            }
+
+            if (Zone.C.equals(zone)) {
+                if ((newHeight + originY) > region.getParent().getBoundsInLocal().getHeight()) {
+                    originY = region.getParent().getBoundsInLocal().getHeight() - newHeight;
+                }
+                if ((newWidth + originX) > region.getParent().getBoundsInLocal().getWidth()) {
+                    originX = region.getParent().getBoundsInLocal().getWidth() - newWidth;
+                }
+            } else {
+                if ((newHeight + originY) > region.getParent().getBoundsInLocal().getHeight()) {
+                    newHeight = region.getParent().getBoundsInLocal().getHeight() - originY;
+                }
+                if ((newWidth + originX) > region.getParent().getBoundsInLocal().getWidth()) {
+                    newWidth = region.getParent().getBoundsInLocal().getWidth() - originX;
+                }
+            }
+        }
+        if (newWidth < MIN_SIZE) {
+            newWidth = MIN_SIZE;
+        }
+        if (newHeight < MIN_SIZE) {
+            newHeight = MIN_SIZE;
+        }
+
+        if (!Zone.C.equals(zone)) {
+            // need to set Pref Height/Width otherwise they act as minima.
+            if(allowHeightResize) {
+                region.setMinHeight(newHeight);
+                region.setPrefHeight(newHeight);
+            }
+            if(allowWidthResize) {
+                region.setMinWidth(newWidth);
+                region.setPrefWidth(newWidth);
+            }
+        }
+        if(allowMove) {
+            region.relocate(originX, originY);
+        }
+
+        y = allowHeightResize ? event.getSceneY() : y;
+        x = allowWidthResize ? event.getSceneX() : x;
+
+
+    }
+
+    protected void mousePressed(MouseEvent event) {
+
+        // ignore clicks outside of the draggable margin
+        if (!isInDraggableZone(event)) {
+            return;
+        }
+
+        dragging = true;
+
+        // make sure that the minimum height is set to the current height once,
+        // setting a min height that is smaller than the current height will
+        // have no effect
+        if (!initMinHeight) {
+            region.setMinHeight(region.getHeight());
+            initMinHeight = true;
+        }
+
+        y = event.getSceneY();
+
+        if (!initMinWidth) {
+            region.setMinWidth(region.getWidth());
+            initMinWidth = true;
+        }
+
+        x = event.getSceneX();
+    }
+
+}

--- a/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
@@ -26,6 +26,7 @@ package com.intuit.karate.ui;
 import com.intuit.karate.cucumber.FeatureSection;
 import gherkin.formatter.model.Feature;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
@@ -33,24 +34,30 @@ import javafx.scene.text.TextFlow;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.intuit.karate.ui.App.PADDING_INSET;
+
 /**
  *
  * @author pthomas3
  */
-public class FeaturePanel extends ScrollPane {
+public class FeaturePanel extends BorderPane {
 
+    private final ScrollPane scrollPane;
     private final VBox content;
     private final AppSession session;
     private final List<SectionPanel> sectionPanels;
 
     public FeaturePanel(AppSession session) {
-        content = new VBox(0);
-        setContent(content);
-        setFitToWidth(true);
+        this.setPadding(PADDING_INSET);
+        this.scrollPane = new ScrollPane();
+        content = new VBox(5.0);
+        this.scrollPane.setContent(content);
+        this.scrollPane.setFitToWidth(true);
         this.session = session;
         int sectionCount = session.getFeature().getSections().size();
         sectionPanels = new ArrayList(sectionCount);
         addSections();
+        this.setCenter(scrollPane);
     }
     
     private void addSections() {

--- a/karate-core/src/main/java/com/intuit/karate/ui/LogPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/LogPanel.java
@@ -29,17 +29,19 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 
+import static com.intuit.karate.ui.App.PADDING_INSET;
+
 /**
  *
  * @author pthomas3
  */
 public class LogPanel extends BorderPane {
-    
+
     private final TextArea textArea;
     private final TextAreaLogAppender appender;
-    
+
     public LogPanel() {
-        setPadding(new Insets(2.0));
+        setPadding(PADDING_INSET);
         VBox content = new VBox(2.0);
         setCenter(content);
         textArea = new TextArea();
@@ -48,6 +50,7 @@ public class LogPanel extends BorderPane {
         clearButton.setOnAction(e -> textArea.clear());        
         appender = new TextAreaLogAppender(textArea);
         content.getChildren().addAll(textArea, clearButton);
+        DragResizer.makeResizable(textArea, false, false, true, false);
     }
     
     public void append(String s) {

--- a/karate-core/src/main/java/com/intuit/karate/ui/VarsPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/VarsPanel.java
@@ -31,6 +31,8 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.BorderPane;
 
+import static com.intuit.karate.ui.App.PADDING_INSET;
+
 /**
  *
  * @author pthomas3
@@ -39,9 +41,10 @@ public class VarsPanel extends BorderPane {
     
     private final AppSession session;
     private final TableView<Var> table;
-        
+
     public VarsPanel(AppSession session) {
-        this.session = session;        
+        this.session = session;
+        this.setPadding(PADDING_INSET);
         table = new TableView();
         table.setPrefWidth(300);
         table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
@@ -69,7 +72,7 @@ public class VarsPanel extends BorderPane {
                 }
             });
             return row ;
-        });        
+        });
     }
     
     public void refresh() {


### PR DESCRIPTION
### Description

#306 | Ravinder | Changes to make log text box drag resizable. Added component DragResizer which can be used for other panes as well. All the panes in Main BorderPane are now of type BorderPane this means padding can be adjusted for all the panes from one place.
Below is the screen shot of how it looks.
![image](https://user-images.githubusercontent.com/24655564/36663592-fe6c519c-1ad9-11e8-9fe1-bdd010679f24.png)


- Relevant Issues : #306 
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
