### PR TITLE
Issue #390: Conflict between org.slf4j.impl.SimpleLogger and ch.qos.logback.classic.Logger Fix 

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/cucumber/ReporterLogAppender.java
+++ b/karate-core/src/main/java/com/intuit/karate/cucumber/ReporterLogAppender.java
@@ -51,12 +51,10 @@ public class ReporterLogAppender extends AppenderBase<ILoggingEvent> {
 		if (!(LoggerFactory.getILoggerFactory()
 				.getLogger("com.intuit.karate") instanceof ch.qos.logback.classic.Logger)) {
 			ctx = new LoggerContext();
-			this.logger = ctx.getLogger("com.intuit.karate");
 		} else {
 			ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
-			this.logger = (Logger) LoggerFactory.getILoggerFactory().getLogger("com.intuit.karate");
-
 		}
+		this.logger = ctx.getLogger("com.intuit.karate");
 		setName("karate-reporter");
 		setContext(ctx);
 		encoder = new PatternLayoutEncoder();

--- a/karate-core/src/main/java/com/intuit/karate/ui/TextAreaLogAppender.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/TextAreaLogAppender.java
@@ -45,7 +45,16 @@ public class TextAreaLogAppender extends AppenderBase<ILoggingEvent> {
 
     public TextAreaLogAppender(TextArea textArea) {
         this.textArea = textArea;
-        logger = (Logger) LoggerFactory.getLogger("com.intuit.karate");
+        LoggerContext ctx = null;
+		if (!(LoggerFactory.getILoggerFactory()
+				.getLogger("com.intuit.karate") instanceof ch.qos.logback.classic.Logger)) {
+			ctx = new LoggerContext();
+			this.logger = ctx.getLogger("com.intuit.karate");
+		} else {
+			ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+			this.logger = (Logger) LoggerFactory.getILoggerFactory().getLogger("com.intuit.karate");
+
+		}
         setName("karate-ui");
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
         setContext(lc);

--- a/karate-core/src/main/java/com/intuit/karate/ui/TextAreaLogAppender.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/TextAreaLogAppender.java
@@ -49,15 +49,12 @@ public class TextAreaLogAppender extends AppenderBase<ILoggingEvent> {
 		if (!(LoggerFactory.getILoggerFactory()
 				.getLogger("com.intuit.karate") instanceof ch.qos.logback.classic.Logger)) {
 			ctx = new LoggerContext();
-			this.logger = ctx.getLogger("com.intuit.karate");
 		} else {
 			ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
-			this.logger = (Logger) LoggerFactory.getILoggerFactory().getLogger("com.intuit.karate");
-
-		}
+        }
+        this.logger = ctx.getLogger("com.intuit.karate");
         setName("karate-ui");
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        setContext(lc);
+        setContext(ctx);
         encoder = new PatternLayoutEncoder();
         encoder.setPattern("%d{HH:mm:ss.SSS} %-5level - %msg%n");
         encoder.setContext(context);

--- a/karate-web/src/main/java/com/intuit/karate/web/config/WebSocketLogAppender.java
+++ b/karate-web/src/main/java/com/intuit/karate/web/config/WebSocketLogAppender.java
@@ -48,9 +48,17 @@ public class WebSocketLogAppender extends AppenderBase<ILoggingEvent> {
     public WebSocketLogAppender(String sessionId) {
         // deliberately NOT the com.intuit form else will pick up all those
         // this is supposed to isolate user-session s
-        this.sessionId = sessionId;
-        logger = (Logger) LoggerFactory.getLogger(sessionId);
         sb = new StringBuilder();
+    	this.sessionId = sessionId;
+        LoggerContext ctx = null;
+		if (!(LoggerFactory.getILoggerFactory()
+				.getLogger(sessionId) instanceof ch.qos.logback.classic.Logger)) {
+			ctx = new LoggerContext();
+			this.logger = ctx.getLogger(sessionId);
+		} else {
+			ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+			this.logger = (Logger) LoggerFactory.getILoggerFactory().getLogger(sessionId);
+		}
         setName("karate-web");
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
         setContext(lc);

--- a/karate-web/src/main/java/com/intuit/karate/web/config/WebSocketLogAppender.java
+++ b/karate-web/src/main/java/com/intuit/karate/web/config/WebSocketLogAppender.java
@@ -53,15 +53,13 @@ public class WebSocketLogAppender extends AppenderBase<ILoggingEvent> {
         LoggerContext ctx = null;
 		if (!(LoggerFactory.getILoggerFactory()
 				.getLogger(sessionId) instanceof ch.qos.logback.classic.Logger)) {
-			ctx = new LoggerContext();
-			this.logger = ctx.getLogger(sessionId);
+			ctx = new LoggerContext();	
 		} else {
 			ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
-			this.logger = (Logger) LoggerFactory.getILoggerFactory().getLogger(sessionId);
-		}
+        }
+        this.logger = ctx.getLogger(sessionId);
         setName("karate-web");
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        setContext(lc);
+        setContext(ctx);
         encoder = new PatternLayoutEncoder();
         encoder.setPattern("%d{HH:mm:ss.SSS} %-5level - %msg%n");
         encoder.setContext(context);


### PR DESCRIPTION
This pull contains fix for
```
Caused by: java.lang.ClassCastException: org.slf4j.impl.SimpleLogger cannot be cast to ch.qos.logback.classic.Logger
```

This issue mostly seen if you are using 3.1.x maven with a custom maven mojo to execute karate tests.
