### PR TITLE
fix(windows): files read with CRLF

### DIFF
--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/demos/type-conv.feature
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/demos/type-conv.feature
@@ -32,8 +32,10 @@ Scenario Outline: multi-line text in a scenario outline
 Scenario: multi-line string expression
     # this is normally never required since you can use replace
     * def name = 'Luke Skywalker'
-    * string query = '{\n  hero(name: "' + name + '") {\n    height\n    mass\n  }\n}'
-    * match query == read('query.txt')
+    * string expectedOnUnix = '{\n  hero(name: "' + name + '") {\n    height\n    mass\n  }\n}'
+    * string expectedOnWindows = '{\r\n  hero(name: "' + name + '") {\r\n    height\r\n    mass\r\n  }\r\n}'
+    * def actual = read('query.txt')
+    * assert actual === expectedOnUnix || actual === expectedOnWindows
 
 Scenario: string to json
     # this would be of type string (not JSON)


### PR DESCRIPTION
On Windows, Karate does not compile due to 3 errors: here is the first fix.

On Windows, a git clone will transform line terminations to Windows ones (by default, can be configured, but don't count on all developers doing this, and it triggers other bugs, especially in Eclipse).

So, I modified the test to expect a Windows file too.

Types of change :
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests