### PR TITLE
Issue-479: karate-ui enhanced to create-new/edit-existing/save-modified features

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/cucumber/FeatureWrapper.java
+++ b/karate-core/src/main/java/com/intuit/karate/cucumber/FeatureWrapper.java
@@ -91,8 +91,8 @@ public class FeatureWrapper {
 
     public String joinLines(int startLine, int endLine) {
         StringBuilder sb = new StringBuilder();
-        if (endLine > lines.size() - 1) {
-            endLine = lines.size() - 1;
+        if (endLine > lines.size()) {
+            endLine = lines.size();
         }
         for (int i = startLine; i < endLine; i++) {
             String line = lines.get(i);
@@ -196,6 +196,10 @@ public class FeatureWrapper {
     public FeatureWrapper removeLine(int index) {
         lines.remove(index);
         return new FeatureWrapper(joinLines(), scriptEnv, path, callTag);
+    }
+
+    public FeatureWrapper replaceText(String newText) {
+        return new FeatureWrapper(newText, scriptEnv, path, callTag);
     }
 
     private FeatureWrapper(String text, ScriptEnv scriptEnv, String path, String callTag) {

--- a/karate-core/src/main/java/com/intuit/karate/ui/AppSession.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/AppSession.java
@@ -142,6 +142,11 @@ public class AppSession {
         headerPanel.initTextContent();
     }
 
+    public void replaceFeature(String text) {
+        feature = feature.replaceText(text);
+        featurePanel.refresh();
+    }
+
     public ObservableList<Var> getVars() {
         if (backend.getStepDefs() == null) {
             return FXCollections.emptyObservableList();

--- a/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
@@ -86,4 +86,10 @@ public class FeaturePanel extends BorderPane {
         }
     }    
 
+    public void refresh() {
+        sectionPanels.clear();
+        content.getChildren().clear();
+        addSections();
+    }
+
 }

--- a/karate-core/src/main/java/com/intuit/karate/ui/HeaderPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/HeaderPanel.java
@@ -47,7 +47,9 @@ public class HeaderPanel extends BorderPane {
     
     private final HBox content;
     private final AppSession session;    
+    private final MenuItem newFileMenuItem;
     private final MenuItem openFileMenuItem;
+    private final MenuItem saveFileMenuItem;
     private final MenuItem openDirectoryMenuItem;
     private final MenuItem openImportMenuItem;
     private final TextArea textContent;
@@ -76,11 +78,12 @@ public class HeaderPanel extends BorderPane {
         });        
         MenuBar menuBar = new MenuBar();
         Menu fileMenu = new Menu("File");
+        newFileMenuItem = new MenuItem("New");
         openFileMenuItem = new MenuItem("Open");
-        fileMenu.getItems().addAll(openFileMenuItem);
-
+        saveFileMenuItem = new MenuItem("Save");
         openDirectoryMenuItem = new MenuItem("Load Directory");
-        fileMenu.getItems().addAll(openDirectoryMenuItem);
+        fileMenu.getItems().addAll(newFileMenuItem, openFileMenuItem,
+                openDirectoryMenuItem, saveFileMenuItem);
 
         Menu importMenu = new Menu("Import");
         openImportMenuItem = new MenuItem("Open");
@@ -113,9 +116,17 @@ public class HeaderPanel extends BorderPane {
     private String getContentButtonText(boolean visible) {
         return visible ? "Hide Raw" : "Show Raw";
     }
+
+    public void setNewFileAction(EventHandler<ActionEvent> handler) {
+        newFileMenuItem.setOnAction(handler);
+    }
     
     public void setFileOpenAction(EventHandler<ActionEvent> handler) {
         openFileMenuItem.setOnAction(handler);
+    }
+
+    public void setFileSaveAction(EventHandler<ActionEvent> handler) {
+        saveFileMenuItem.setOnAction(handler);
     }
 
     public void setDirectoryOpenAction(EventHandler<ActionEvent> handler) {
@@ -134,12 +145,11 @@ public class HeaderPanel extends BorderPane {
     public void rebuildFeatureIfTextChanged() {
         String newText = textContent.getText();
         if (!newText.equals(oldText)) {
-            Alert alert = new Alert(AlertType.INFORMATION);
-            alert.setHeaderText("Read Only");
-            alert.setTitle("Not Implemented");
-            alert.setContentText("Raw text editing is not supported.");
-            alert.show();
-            textContent.setText(oldText);
+            try {
+                session.replaceFeature(newText);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
     

--- a/karate-core/src/test/java/com/intuit/karate/cucumber/CucumberUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/cucumber/CucumberUtilsTest.java
@@ -99,7 +99,7 @@ public class CucumberUtilsTest {
         fw = fw.addLine(9, "Then assert 2 == 2");
         List<String> lines = fw.getLines();
         printLines(lines);
-        assertEquals(16, lines.size());
+        assertEquals(17, lines.size());
         assertEquals(1, fw.getSections().size());
     }
     
@@ -115,7 +115,7 @@ public class CucumberUtilsTest {
         fw = fw.replaceLines(line, line, "Then assert 2 == 2");
         List<String> lines = fw.getLines();
         printLines(lines);
-        assertEquals(15, lines.size());
+        assertEquals(16, lines.size());
         assertEquals(1, fw.getSections().size());
     }
 
@@ -130,7 +130,7 @@ public class CucumberUtilsTest {
         fw = fw.replaceStep(step, "Then assert 2 == 2");
         List<String> lines = fw.getLines();
         printLines(lines);
-        assertEquals(12, lines.size());
+        assertEquals(13, lines.size());
         assertEquals("# another comment", fw.getLines().get(9));
         assertEquals("Then assert 2 == 2", fw.getLines().get(10));
         assertEquals("Then match b == { foo: 'bar'}", fw.getLines().get(11));


### PR DESCRIPTION
### Description
Added support in karate-ui for 
1. creating new features (with a sample template initially saved to a temporary `noname.feature`)
1. edit existing features (both in Raw-Content area, and also in the text area of individual Steps)
1. save currently loaded feature
1. save imported postman collection into a temporary `noname.feature` which can be viewed, edited and saved as feature file of choice
1. fixed a minor issue with off-by-one error in FeatureWrapper (https://github.com/vmchukky/karate/blob/Issue-479/karate-core/src/main/java/com/intuit/karate/cucumber/FeatureWrapper.java#L94-L95) which was causing removal of last line from feature each time `joinLines(int startLine, int endLine)` is invoked

Note:
1. To add new steps one has to add text in Raw-Content area (corresponding Steps will be automatically added below, only after losing focus from Raw-Content area)
1. After updating the feature (either in Raw-Content area or in TextArea of individual steps) one has to trigger focus-lost from that TextArea for the UI to take the modification (please do this, `clicking in some other part of the UI`, before trying to save the changes)

- Relevant Issues : https://github.com/intuit/karate/issues/479
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
