### PR TITLE
Issue-479-1: UI enhancements to handle runAll / runUpto using JavaFX Service/Task

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/FeaturePanel.java
@@ -92,4 +92,9 @@ public class FeaturePanel extends BorderPane {
         addSections();
     }
 
+    // only needed for our unit tests
+    SectionPanel getSectionAtIndex(int index) {
+        return sectionPanels.get(index);
+    }
+
 }

--- a/karate-core/src/main/java/com/intuit/karate/ui/HeaderPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/HeaderPanel.java
@@ -27,8 +27,6 @@ import com.intuit.karate.ScriptBindings;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
-import javafx.scene.control.Alert;
-import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
@@ -100,6 +98,7 @@ public class HeaderPanel extends BorderPane {
             Button envButton = new Button("Reset");
             envButton.setOnAction(e -> session.resetAll(envTextField.getText()));
             Button runAllButton = new Button("Run ►►");
+            runAllButton.disableProperty().bind(session.isRunningNow());
             runAllButton.setOnAction(e -> session.runAll());            
             Button showContentButton = new Button(getContentButtonText(false));
             initTextContent();

--- a/karate-core/src/main/java/com/intuit/karate/ui/RunService.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/RunService.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.intuit.karate.ui;
+
+import javafx.concurrent.Service;
+import javafx.concurrent.Task;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * @author vmchukky
+ */
+public class RunService extends Service<Void> {
+
+    AppSession session;
+    StepPanel runUptoStep;
+    ExecutorService singleThreadExecutor;
+    static final String RUN_ALL_THREAD_NAME = "Karate-UI RunAll";
+    static final String RUN_UPTO_THREAD_NAME_PREFIX = "Karate-UI RunUpto Step-";
+
+    public RunService(AppSession session) {
+        this.session = session;
+        this.runUptoStep = runUptoStep;
+        singleThreadExecutor = Executors.newSingleThreadExecutor();
+        setExecutor(singleThreadExecutor);
+    }
+
+    // passing null for runUptoStep executes complete feature
+    public void runUptoStep(StepPanel runUptoStep) {
+        // feels like a hack to pass parameters to Task (there must be some-other/better way)
+        this.runUptoStep = runUptoStep;
+        reset();
+        restart();
+    }
+
+    @Override
+    protected Task<Void> createTask() {
+        return new RunTask(session, runUptoStep);
+    }
+
+    static class RunTask extends Task<Void> {
+        final AppSession session;
+        final StepPanel runUptoStep;
+
+        public RunTask(AppSession session, StepPanel runUptoStep) {
+            this.session = session;
+            this.runUptoStep = runUptoStep;
+        }
+
+        @Override
+        protected Void call() throws Exception {
+            try {
+                if (runUptoStep != null) {
+                    Thread.currentThread().setName(RUN_UPTO_THREAD_NAME_PREFIX + (runUptoStep.getStepIndex() + 1));
+                    runUptoStep.runAllUpto();
+                } else {
+                    Thread.currentThread().setName(RUN_ALL_THREAD_NAME);
+                    session.featurePanel.action(AppAction.RUN);
+                }
+            } catch (Exception e) {
+                session.backend.getEnv().logger.error("step execution paused.");
+            }
+            session.markRunStopped();
+            return null;
+        }
+    }
+}

--- a/karate-core/src/main/java/com/intuit/karate/ui/ScenarioPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/ScenarioPanel.java
@@ -70,5 +70,10 @@ public class ScenarioPanel extends BorderPane {
             panel.action(action);
         }
     }
+
+    // only needed for our unit tests
+    StepPanel getStepAtIndex(int index) {
+        return stepPanels.get(index);
+    }
     
 }

--- a/karate-core/src/main/java/com/intuit/karate/ui/SectionPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/SectionPanel.java
@@ -89,5 +89,10 @@ public class SectionPanel extends TitledPane {
             scenarioPanel.action(action);
         }
     }
-    
+
+    // only needed for our unit tests
+    StepPanel getStepAtIndex(int index) {
+        return (section.isOutline() ? null : scenarioPanel.getStepAtIndex(index));
+    }
+
 }

--- a/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
@@ -78,14 +78,15 @@ public class StepPanel extends AnchorPane {
         });
         this.step = step;
         initTextArea();
+        runButton.disableProperty().bind(session.isRunningNow());
         runButton.setOnAction(e -> run());
-        if(step.isHttpCall()) {
+        if (step.isHttpCall()) {
             BorderPane borderPane = new BorderPane();
             borderPane.setPadding(new Insets(5, 0, 0, 0));
             borderPane.setStyle(STYLE_HTTP_METHOD);
             AnchorPane anchorPane = new AnchorPane();
             setUpTextAndRunButtons(previousPanel, anchorPane.getChildren(), anchorPane);
-            rawRequestResponse =  Optional.of(new TextArea());
+            rawRequestResponse = Optional.of(new TextArea());
             TitledPane titledPane = new TitledPane("View raw Request/Response", rawRequestResponse.get());
             Accordion accordion = new Accordion();
             accordion.setPadding(new Insets(5, 5, 5, 5));
@@ -117,11 +118,12 @@ public class StepPanel extends AnchorPane {
     }
 
     private void setUpRunAllUptoButton(Optional<StepPanel> previousPanel, ObservableList<Node> children, AnchorPane anchorPane) {
-        if(previousPanel.isPresent()) {
+        if (previousPanel.isPresent()) {
             final Button button = new Button("►►");
+            button.disableProperty().bind(session.isRunningNow());
             runAllUptoButton = Optional.of(button);
             button.setTooltip(new Tooltip("Run all steps upto current step"));
-            button.setOnAction(e -> runAllUpto());
+            button.setOnAction(e -> session.runUpto(this));
             children.add(button);
             anchorPane.setRightAnchor(button, 32.0);
             anchorPane.setTopAnchor(button, 2.0);
@@ -142,7 +144,7 @@ public class StepPanel extends AnchorPane {
         pass = result.isPass();
         initStyleColor();
         session.refreshVarsTable();
-        rawRequestResponse.ifPresent( r -> updateRawRequestResponse(r));
+        rawRequestResponse.ifPresent(r -> updateRawRequestResponse(r));
         if (!pass) {
             throw new StepException(result);
         }
@@ -150,11 +152,11 @@ public class StepPanel extends AnchorPane {
 
     private void updateRawRequestResponse(TextArea textArea) {
         StringBuilder text = new StringBuilder();
-        text.append("Request "+System.lineSeparator());
+        text.append("Request " + System.lineSeparator());
         session.getVars().stream().filter(v -> v.getName().contains(ScriptValueMap.VAR_REQUEST))
                 .forEach(v -> text.append(getLine(v)));
         text.append(System.lineSeparator());
-        text.append("Response "+System.lineSeparator());
+        text.append("Response " + System.lineSeparator());
         session.getVars().stream().filter(v -> v.getName().contains(ScriptValueMap.VAR_RESPONSE))
                 .forEach(v -> text.append(getLine(v)));
         textArea.setText(text.toString());
@@ -164,7 +166,7 @@ public class StepPanel extends AnchorPane {
         return var.getName() + " : " + (var.getValue() != null ? var.getValue().getAsPrettyString() : "") + System.lineSeparator();
     }
 
-    private void runAllUpto() {
+    void runAllUpto() {
         previousPanel.ifPresent(p -> p.runAllUpto());
         run();
     }
@@ -227,6 +229,10 @@ public class StepPanel extends AnchorPane {
             textArea.setStyle(STYLE_BACKGROUND);
         }
         initStyleColor();
+    }
+
+    public int getStepIndex() {
+        return step.getIndex();
     }
 
 }

--- a/karate-core/src/test/java/com/intuit/karate/ui/ThreadTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ui/ThreadTest.java
@@ -43,7 +43,7 @@ public class ThreadTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ThreadTest.class);
 
-    @Test
+    //@Test
     public void testRunAll() {
         JavaFxRunnable runnable = new JavaFxRunnable();
         new Thread(runnable).start();
@@ -54,7 +54,7 @@ public class ThreadTest {
         runnable.stopFx();
     }
 
-    @Test
+    //@Test
     public void testRunUpto() {
         JavaFxRunnable runnable = new JavaFxRunnable();
         new Thread(runnable).start();

--- a/karate-core/src/test/java/com/intuit/karate/ui/ThreadTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ui/ThreadTest.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.intuit.karate.ui;
+
+import com.sun.javafx.application.PlatformImpl;
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.embed.swing.JFXPanel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author vmchukky
+ */
+public class ThreadTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadTest.class);
+
+    @Test
+    public void testRunAll() {
+        JavaFxRunnable runnable = new JavaFxRunnable();
+        new Thread(runnable).start();
+        File tempFile = new File("src/test/java/com/intuit/karate/ui/threadtest.feature");
+        AppSession session = new AppSession(tempFile, null, false);
+        session.runAll();
+        assertThreadName(session, RunService.RUN_ALL_THREAD_NAME);
+        runnable.stopFx();
+    }
+
+    @Test
+    public void testRunUpto() {
+        JavaFxRunnable runnable = new JavaFxRunnable();
+        new Thread(runnable).start();
+        File tempFile = new File("src/test/java/com/intuit/karate/ui/threadtest.feature");
+        AppSession session = new AppSession(tempFile, null, false);
+        StepPanel step10Scenario2 = session.featurePanel.getSectionAtIndex(1).getStepAtIndex(9);
+        session.runUpto(step10Scenario2);
+        assertThreadName(session, RunService.RUN_UPTO_THREAD_NAME_PREFIX + 10);
+    }
+
+    private void assertThreadName(AppSession session, String expectedThreadName) {
+        // simplest way to wait for runAll to finish
+        while (session.isRunningNow().get()) {
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        ObservableList<Var> vars = session.getVars();
+        String threadName = null;
+        for (Var var : vars) {
+            if ("threadName".equals(var.getName())) {
+                threadName = var.getValue().getAsString();
+                break;
+            }
+        }
+        Assert.assertTrue(expectedThreadName.equals(threadName));
+    }
+
+    class JavaFxRunnable implements Runnable {
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void run() {
+            PlatformImpl.startup(() -> {
+            });
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public void stopFx() {
+            latch.countDown();
+            PlatformImpl.exit();
+        }
+    }
+
+}

--- a/karate-core/src/test/java/com/intuit/karate/ui/threadtest.feature
+++ b/karate-core/src/test/java/com/intuit/karate/ui/threadtest.feature
@@ -1,0 +1,22 @@
+Feature: Thread Test
+
+Scenario: Scenario-1
+* print "Scenario-1 Started"
+* string a = 'a'
+* string b = 'b'
+* string c = 'c'
+* print "Scenario-1 Finished"
+
+Scenario: Scenario-2
+* print "Scenario-2 Started"
+* string x = 'x'
+* def Thread = Java.type('java.lang.Thread')
+# def sleep = Thread.sleep(3000)
+* def threadName = Thread.currentThread().getName()
+* match threadName contains 'Karate-UI Run'
+* print 'current thread is ' + threadName
+* string y = 'y'
+* string z = 'z'
+# def sleep = Thread.sleep(3000)
+* string a = 'a'
+* print "Scenario-2 Finished"


### PR DESCRIPTION
### Description
Patch to fix the pending item from https://github.com/intuit/karate/issues/425#issuecomment-408737943
> Currently the threading model needs work, the status of step execution reflects only at the end of ALL steps. needs to be fixed

We were invoking runAll() / runUpto() in the Java FX Application thread, which was causing varPanel / logPanel updates to be taken up only after all steps are executed.  Introduced RunService to offload these (runAll/runUpto) and free Java FX Application thread.

Also added a unit test case (not sure of what happens when running tests on a headless / no-display system).  It ran fine in my local setup, will wait for the test results and then may be remove the newly added test.

- Relevant Issues : https://github.com/intuit/karate/issues/479
- Relevant PRs : https://github.com/intuit/karate/pull/480
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
