### PR TITLE
Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ And you don't need to create additional Java classes for any of the payloads tha
     | <a href="#not-contains"><code>match !contains</code></a>
     | <a href="#match-each"><code>match each</code></a>
     | <a href="#fuzzy-matching">Fuzzy Matching</a>
-    | <a href="#contains-shortcuts"><code>contains</code> short-cuts</a>
-    | <a href="#schema-validation">Schema Validation</a> 
+    | <a href="#schema-validation">Schema Validation</a>
+    | <a href="#contains-short-cuts"><code>contains</code> short-cuts</a>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
### Description

Dead link due to naming issues.

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation