### PR TITLE
fix content-lenght issue for input stream entity

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpUtils.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpUtils.java
@@ -96,7 +96,7 @@ public class ApacheHttpUtils {
     
     public static HttpEntity getEntity(InputStream is, String mediaType, Charset charset) {
         try {
-            return new InputStreamEntity(is, getContentType(mediaType, charset));
+            return new InputStreamEntity(is, is.available(), getContentType(mediaType, charset));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }         


### PR DESCRIPTION
In reference to #491,

This pull requests fixes the content-length issue, when working with files ( InputStream). The main issue was due to the InputStreamEntity used in https://github.com/intuit/karate/blob/master/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpUtils.java#L99

```
    public static HttpEntity getEntity(InputStream is, String mediaType, Charset charset) {
        try {
            return new InputStreamEntity(is, getContentType(mediaType, charset));
        } catch (Exception e) {
            throw new RuntimeException(e);
        }         
    } 

```

the `new InputStreamEntity(is, getContentType(mediaType, charset));` sets the content lenght to -1 underneath:

```
    public InputStreamEntity(InputStream instream, ContentType contentType) {
        this(instream, -1L, contentType);
    }
```

the constructor ` public InputStreamEntity(InputStream instream, long length, ContentType contentType)` should be used instead. 