### PR TITLE
It is not necessary to override the onApplicationEvent method only to retrieve the port within the spring context.

### DIFF
--- a/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
@@ -32,21 +32,17 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
 /**
+ *
  * @author pthomas3
  */
 @Component
-public class ServerStartedInitializingBean implements ApplicationRunner {
+public class ServerStartedInitializingBean implements ApplicationRunner{
 
     private static final Logger logger = LoggerFactory.getLogger(ServerStartedInitializingBean.class);
-
-    private int localPort;
-
-    public int getLocalPort() {
-        return localPort;
-    }
 
     @Override
     public void run(ApplicationArguments aa) throws Exception {
         logger.info("server started with args: {}", Arrays.toString(aa.getSourceArgs()));
     }
+
 }

--- a/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
@@ -24,38 +24,29 @@
 package com.intuit.karate.demo.config;
 
 import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 /**
- *
  * @author pthomas3
  */
 @Component
-public class ServerStartedInitializingBean implements ApplicationRunner, ApplicationListener<EmbeddedServletContainerInitializedEvent> {
-	
-	private static final Logger logger = LoggerFactory.getLogger(ServerStartedInitializingBean.class);
+public class ServerStartedInitializingBean implements ApplicationRunner {
 
-	private int localPort;	
+    private static final Logger logger = LoggerFactory.getLogger(ServerStartedInitializingBean.class);
 
-	public int getLocalPort() {
-		return localPort;
-	}	
-	
-	@Override
-	public void run(ApplicationArguments aa) throws Exception {
-		logger.info("server started with args: {}", Arrays.toString(aa.getSourceArgs()));
-	}
+    private int localPort;
 
-	@Override
-	public void onApplicationEvent(EmbeddedServletContainerInitializedEvent e) {
-		localPort = e.getEmbeddedServletContainer().getPort();
-		logger.info("after runtime init, local server port: {}", localPort);
-	}
+    public int getLocalPort() {
+        return localPort;
+    }
 
+    @Override
+    public void run(ApplicationArguments aa) throws Exception {
+        logger.info("server started with args: {}", Arrays.toString(aa.getSourceArgs()));
+    }
 }

--- a/karate-demo/src/test/java/mock/contract/PaymentService.java
+++ b/karate-demo/src/test/java/mock/contract/PaymentService.java
@@ -1,12 +1,14 @@
 package mock.contract;
 
-import com.intuit.karate.JsonUtils;
-import com.intuit.karate.demo.config.ServerStartedInitializingBean;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+
+import com.intuit.karate.JsonUtils;
+import com.intuit.karate.demo.config.ServerStartedInitializingBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,7 +19,14 @@ import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  *
@@ -94,8 +103,7 @@ public class PaymentService {
     }
 
     public static int getPort(ConfigurableApplicationContext context) {
-        ServerStartedInitializingBean ss = context.getBean(ServerStartedInitializingBean.class);
-        return ss.getLocalPort();
+        return Integer.parseInt(Objects.requireNonNull(context.getEnvironment().getProperty("local.server.port")));
     }
 
     @Bean

--- a/karate-demo/src/test/java/ssl/TestService.java
+++ b/karate-demo/src/test/java/ssl/TestService.java
@@ -1,5 +1,7 @@
 package ssl;
 
+import java.util.Objects;
+
 import com.intuit.karate.demo.config.ServerStartedInitializingBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +12,9 @@ import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  *
@@ -48,8 +52,7 @@ public class TestService {
     }
 
     public static int getPort(ConfigurableApplicationContext context) {
-        ServerStartedInitializingBean ss = context.getBean(ServerStartedInitializingBean.class);
-        return ss.getLocalPort();
+        return Integer.parseInt(Objects.requireNonNull(context.getEnvironment().getProperty("local.server.port")));
     }
 
     @Bean

--- a/karate-demo/src/test/java/test/ServerStart.java
+++ b/karate-demo/src/test/java/test/ServerStart.java
@@ -23,8 +23,9 @@
  */
 package test;
 
+import java.util.Objects;
+
 import com.intuit.karate.demo.Application;
-import com.intuit.karate.demo.config.ServerStartedInitializingBean;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,8 +53,7 @@ public class ServerStart {
             }
         }
         context = Application.run(args);
-        ServerStartedInitializingBean ss = context.getBean(ServerStartedInitializingBean.class);
-        port = ss.getLocalPort();
+        port = Integer.parseInt(Objects.requireNonNull(context.getEnvironment().getProperty("local.server.port")));
         logger.info("started server on port: {}", port);
         if (wait) {
             int stopPort = port + 1;


### PR DESCRIPTION
It is not necessary to override the onApplicationEvent method only to retrieve the port within the spring context.

### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
