### PR TITLE
CI-482-2: updated callPattern to catchup with step-def-text without '*'

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
@@ -66,7 +66,7 @@ public class StepPanel extends AnchorPane {
     private static final String STYLE_METHOD = "-fx-base: #34BFFF";
     private static final String STYLE_DEFAULT = "-fx-base: #F0F0F0";
     private static final String STYLE_BACKGROUND = "-fx-text-fill: #8D9096";
-    private static final Pattern callPattern = Pattern.compile("\\s*\\*\\s*(def\\s*\\w+\\s*=)?\\s*call\\s*read.*");
+    private static final Pattern callPattern = Pattern.compile("\\s*(.*=)?\\s*call\\s*read.*");
 
     public StepPanel(AppSession session, Step step, Optional<StepPanel> previousPanel) {
         this.session = session;


### PR DESCRIPTION
### Description
I was testing code from cukexit and noticed stepDef text no longer has `*` prefix.  Simple fix to callPattern definition.

- Relevant Issues : https://github.com/intuit/karate/issues/482
- Relevant PRs : https://github.com/intuit/karate/pull/495
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation