### PR TITLE
Add a Demo for JWT

### DIFF
--- a/karate-demo/src/test/java/demo/jwt/JwtRunner.java
+++ b/karate-demo/src/test/java/demo/jwt/JwtRunner.java
@@ -1,0 +1,9 @@
+package demo.oauth;
+
+import com.intuit.karate.junit4.Karate;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+public class JwtRunner {
+
+}

--- a/karate-demo/src/test/java/demo/jwt/jwt.feature
+++ b/karate-demo/src/test/java/demo/jwt/jwt.feature
@@ -1,0 +1,36 @@
+Feature: JWT Test
+
+Background:
+* url 'http://klingman.us/api/jwtTest'
+* def parseJwtPayload =
+  """
+  function(token) {
+      var base64Url = token.split('.')[1];
+      var base64Str = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+      var Base64 = Java.type('java.util.Base64');
+      var decoded = Base64.getDecoder().decode(base64Str);
+      var String = Java.type('java.lang.String')
+      return new String(decoded)
+  };
+  """
+
+Scenario: jwt flow
+Given path  'authenticate'
+And request {user: "test@example.com", password: "testPass"}
+When method POST
+Then status 200
+* def accessToken = response['token']
+* json result = parseJwtPayload(accessToken)
+* match result == {user: "test@example.com", role: "editor", exp: "#number", iss: "klingman"}
+
+* path 'resource'
+* header Authorization = 'Bearer ' + accessToken
+* method get
+* status 200
+
+Scenario: Access Denied
+Given path  'authenticate'
+And request {user: "test@example.com", password: "wrong"}
+When method POST
+Then status 403
+


### PR DESCRIPTION
### Description

This pull adds a demo for JWT tokens.  It was requested on Stack Overflow: https://stackoverflow.com/questions/46450804/buffer-in-js-file-isnt-recognized-api-tests-automation-with-karate-framework/52205655?noredirect=1#comment91395237_52205655

- Type of change: Addition or Improvement of documentation

I was unable to find any hosted JWT token websites to use for the demo URL.
The source for the demo is very simple so if you have a spot to host it, I'm happy to have it moved over.  (It's currently in PHP but should be easy to convert.)

```php
Route::post('/jwtTest/authenticate', function (Illuminate\Http\Request $request) {
    $token = [];
    $token['token'] = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoidGVzdEBleGFtcGxlLmNvbSIsInJvbGUiOiJlZGl0b3IiLCJleHAiOjk5OTk5OTk5OSwiaXNzIjoia2xpbmdtYW4ifQ._D2tcNJN6mawerckbNotuINRm_8bRaXVi18hgsuOk9Y';
    if ($request->input('user') == 'test@example.com' && $request->input('password') == 'testPass') {
        return response()->json($token);
    } else {
        return response()->json(['error' => 'Not authorized.'], 403);
    }
});
Route::get('/jwtTest/resource', function (Illuminate\Http\Request $request) {
    return response()->json(['result' => 'Hey (Note: This page actually always returns and never validates the token...)']);
});
```