### PR TITLE
Feature parser scenario outline with no examples

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureParser.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureParser.java
@@ -152,6 +152,10 @@ public class FeatureParser extends KarateParserBaseListener {
     private static Table toTable(KarateParser.TableContext ctx) {
         List<TerminalNode> nodes = ctx.TABLE_ROW();
         int rowCount = nodes.size();
+        if(rowCount < 1) {
+        	// if scenario outline found without examples
+        	return null;
+        }
         List<List<String>> rows = new ArrayList(rowCount);
         List<Integer> lineNumbers = new ArrayList(rowCount);
         for (TerminalNode node : nodes) {


### PR DESCRIPTION
Fix for IndexOutOfBoundsException when feature parser tries to build Table object while there are no `Examples: ` table row available for the scenario outline.

The approach is to skip table object creation when there is no example table row available and let the feature parser error listener throw exception afterward.

sample feature to replicate this Exception: [invalidScenarioOutline.zip](https://github.com/intuit/karate/files/2475825/invalidScenarioOutline.zip)

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ✓] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation


