### PR TITLE
Refactored usage of System.nanoTime

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -300,7 +300,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
             throw new RuntimeException(e);
         }
         HttpRequest actualRequest = context.getPrevRequest();
-        HttpResponse response = new HttpResponse(actualRequest.getStartTime(), actualRequest.getEndTime());
+        HttpResponse response = new HttpResponse(actualRequest.getStartTimeMillis(), actualRequest.getEndTimeMillis());
         response.setUri(getRequestUri());
         response.setBody(bytes);
         response.setStatus(httpResponse.getStatusLine().getStatusCode());

--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ResponseLoggingInterceptor.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ResponseLoggingInterceptor.java
@@ -53,7 +53,7 @@ public class ResponseLoggingInterceptor implements HttpResponseInterceptor {
         actual.stopTimer();
         int id = requestInterceptor.getCounter().get();
         StringBuilder sb = new StringBuilder();
-        sb.append("response time in milliseconds: ").append(actual.getResponseTimeFormatted()).append('\n');
+        sb.append("response time in milliseconds: ").append(actual.getResponseTimeMillis()).append('\n');
         sb.append(id).append(" < ").append(response.getStatusLine().getStatusCode()).append('\n');
         LoggingUtils.logHeaders(sb, id, '<', response);
         HttpEntity entity = response.getEntity();

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
@@ -228,7 +228,7 @@ public abstract class HttpClient<T> {
             }
             return response;
         } catch (Exception e) {
-            long startTime = context.getPrevRequest().getStartTime();
+            long startTime = context.getPrevRequest().getStartTimeMillis();
             long responseTime = System.currentTimeMillis() - startTime;
             String message = "http call failed after " + responseTime + " milliseconds for URL: " + getRequestUri();
             context.logger.error(e.getMessage() + ", " + message);

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequest.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequest.java
@@ -23,8 +23,8 @@
  */
 package com.intuit.karate.http;
 
-import com.intuit.karate.core.Engine;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * this is only for capturing what was actually sent on the wire, read-only
@@ -33,42 +33,39 @@ import java.util.List;
  */
 public class HttpRequest {
     
-    private long startTime;
-    private long endTime;
-    private double responseTime;
+    private long startTimeMillis;
+    private long startTimeNanos;
+    private long endTimeMillis;
+    private long responseTimeMillis;
     private String urlBase; // used in mock since uri may start with '/'
     private String uri; // will be full uri including query string
     private String method;    
     private MultiValuedMap headers = new MultiValuedMap();
     private MultiValuedMap params; // only used in mock
     private byte[] body;
-    
-    private long startTimeNanos;
 
-    public long getStartTime() {
-        return startTime;
+    // should not be used for response time calculations, use getResponseTimeMillis directly
+    public long getStartTimeMillis() {
+        return startTimeMillis;
     }
     
     public void startTimer() {
-        startTime = System.currentTimeMillis();
+        startTimeMillis = System.currentTimeMillis();
         startTimeNanos = System.nanoTime();
+    }
+
+    // should not be used for response time calculations, use getResponseTimeMillis directly
+    public long getEndTimeMillis() {
+        return endTimeMillis;
     }    
 
-    public long getEndTime() {
-        return endTime;
-    }    
-
-    public double getResponseTime() {
-        return responseTime;
-    }        
-    
-    public String getResponseTimeFormatted() {
-        return String.format("%.2f", responseTime);
+    public double getResponseTimeMillis() {
+        return responseTimeMillis;
     }
     
     public void stopTimer() {        
-        responseTime = Engine.nanosToMillis(System.nanoTime() - startTimeNanos);
-        endTime = startTime + Math.round(responseTime);
+        responseTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+        endTimeMillis = startTimeMillis + responseTimeMillis;
     }    
     
     public String getUrlBase() {

--- a/karate-jersey/src/main/java/com/intuit/karate/http/jersey/JerseyHttpClient.java
+++ b/karate-jersey/src/main/java/com/intuit/karate/http/jersey/JerseyHttpClient.java
@@ -223,7 +223,7 @@ public class JerseyHttpClient extends HttpClient<Entity> {
             resp = builder.method(method);
         }
         HttpRequest actualRequest = context.getPrevRequest();
-        HttpResponse response = new HttpResponse(actualRequest.getStartTime(), actualRequest.getEndTime());
+        HttpResponse response = new HttpResponse(actualRequest.getStartTimeMillis(), actualRequest.getEndTimeMillis());
         byte[] bytes = resp.readEntity(byte[].class);        
         response.setUri(getRequestUri());
         response.setBody(bytes);

--- a/karate-jersey/src/main/java/com/intuit/karate/http/jersey/LoggingInterceptor.java
+++ b/karate-jersey/src/main/java/com/intuit/karate/http/jersey/LoggingInterceptor.java
@@ -112,7 +112,7 @@ public class LoggingInterceptor implements ClientRequestFilter, ClientResponseFi
         context.logger.debug(sb.toString()); // log request
         // response
         sb = new StringBuilder();
-        sb.append("response time in milliseconds: ").append(actual.getResponseTimeFormatted()).append('\n');
+        sb.append("response time in milliseconds: ").append(actual.getResponseTimeMillis()).append('\n');
         sb.append(id).append(" < ").append(response.getStatus()).append('\n');
         logHeaders(sb, id, '<', response.getHeaders(), null);
         if (response.hasEntity() && isPrintable(response.getMediaType())) {


### PR DESCRIPTION
### Description

Small refactoring for usage of System.nanoTime

Always aim for using the `TimeUnit` or java 8 `Duration`, `Instant` classes when working with times. Dont calculate times by dividing by hand.

- Relevant Issue: https://github.com/intuit/karate/issues/563
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
