### PR TITLE
check if package is null before referencing it

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -365,7 +365,10 @@ public class FileUtils {
 
     public static Path getPathContaining(Class clazz) {
         Package p = clazz.getPackage();
-        String relative = p.getName().replace('.', '/');
+        String relative = "";
+        if (p != null) {
+            relative = p.getName().replace('.', '/');
+        }
         URL url = clazz.getClassLoader().getResource(relative);
         return getPathFor(url, null);
     }


### PR DESCRIPTION
### Description
Fix an issue where you get a NPE if the class the which got passed in was not in a package but at the root level.

- Relevant Issues : 
- Relevant PRs :
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
