### PR TITLE
Remove public modifier

### DIFF
--- a/karate-junit5/src/test/java/karate/SampleTest.java
+++ b/karate-junit5/src/test/java/karate/SampleTest.java
@@ -3,20 +3,20 @@ package karate;
 import com.intuit.karate.junit5.Karate;
 import org.junit.jupiter.api.TestFactory;
 
-public class SampleTest {
+class SampleTest {
 
     @TestFactory
-    public Object testSample() {
+    Object testSample() {
         return Karate.feature("sample").relativeTo(getClass()).run();
     }
     
     @TestFactory
-    public Object testTags() {
+    Object testTags() {
         return Karate.feature("tags").tags("@second").relativeTo(getClass()).run();
     }
 
     @TestFactory
-    public Object testFullPath() {
+    Object testFullPath() {
         return Karate
                 .feature("classpath:karate/tags.feature")
                 .tags("@first").run();


### PR DESCRIPTION
### Description

This PR removes the `public` modifier from the sample test class and the test methods.

For details see https://junit.org/junit5/docs/current/user-guide/#writing-tests-classes-and-methods
which states _"Neither test classes nor test methods need to be `public`"_.

- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
