### PR TITLE
Introduce KarateFactory meta-annotation

### DIFF
--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/KarateFactory.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/KarateFactory.java
@@ -1,0 +1,14 @@
+package com.intuit.karate.junit5;
+
+import org.junit.jupiter.api.TestFactory;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestFactory
+public @interface KarateFactory {
+}

--- a/karate-junit5/src/test/java/karate/SampleTest.java
+++ b/karate-junit5/src/test/java/karate/SampleTest.java
@@ -1,25 +1,26 @@
 package karate;
 
 import com.intuit.karate.junit5.Karate;
-import org.junit.jupiter.api.TestFactory;
+import com.intuit.karate.junit5.KarateFactory;
 
 class SampleTest {
 
-    @TestFactory
-    Object testSample() {
-        return Karate.feature("sample").relativeTo(getClass()).run();
+    @KarateFactory
+    Karate testSample() {
+        return Karate.feature("sample").relativeTo(getClass()).build();
     }
     
-    @TestFactory
-    Object testTags() {
-        return Karate.feature("tags").tags("@second").relativeTo(getClass()).run();
+    @KarateFactory
+    Karate testTags() {
+        return Karate.feature("tags").tags("@second").relativeTo(getClass()).build();
     }
 
-    @TestFactory
-    Object testFullPath() {
+    @KarateFactory
+    Karate testFullPath() {
         return Karate
                 .feature("classpath:karate/tags.feature")
-                .tags("@first").run();
+                .tags("@first")
+                .build();
     }
 
 }


### PR DESCRIPTION
### Description

This commit also enhances the `Karate` class to implement the `Iterable<DynamicNode>` interface. With this both improvements in place the JUnit Jupiter-based tests can be written with only
using Karate API:

```java
    @KarateFactory
    Karate testFullPath() {
        return Karate
                .feature("classpath:karate/tags.feature")
                .tags("@first")
                .build();
    }
```

- Relevant Issue : #569 
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
