### PR TITLE
Set varaibles using table, trail pipe missing - fix for karate UI

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Table.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Table.java
@@ -119,7 +119,9 @@ public class Table {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
+        sb.append('\n');
         for (List<String> row : rows) {
+        	sb.append('|').append('\t');
             for (String s : row) {
                 sb.append(s).append('\t').append('|');
             }


### PR DESCRIPTION
Trail pipe missing in each step on setting variables using table

`toString()` method in the `Table` is not appending pipe before each step, causing an issue in Karate UI while running those in the step.

Example scenario:

```
Scenario:
    Given def mobile = {}
    When set mobile
    |     path     |      value     |
    |    "Apple"   |   "iPhone Xs"  |
    |  "One Plus"  |       "6T"     |
    |   "Samsung"  |     "Note 9"   |
```
Issue before fix,
![setpathissue](https://user-images.githubusercontent.com/26348282/48004584-7bb96a80-e137-11e8-85a3-58b43958e7ee.PNG)

After fix,
![setpathissue_afterfix](https://user-images.githubusercontent.com/26348282/48004609-896ef000-e137-11e8-85f8-072aba0db351.PNG)


- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [1] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
