### PR TITLE
Update scenario description grammar

### DIFF
--- a/karate-core/src/main/antlr4/com/intuit/karate/core/KarateParser.g4
+++ b/karate-core/src/main/antlr4/com/intuit/karate/core/KarateParser.g4
@@ -37,7 +37,7 @@ background: BACKGROUND scenarioDescription step* ;
 
 scenario: tags? SCENARIO scenarioDescription step* ;
 
-scenarioDescription: ~(STAR | GIVEN | WHEN | THEN | AND | BUT | SCENARIO | SCENARIO_OUTLINE)* ;
+scenarioDescription: ~(STAR | GIVEN | WHEN | THEN | AND | BUT | SCENARIO | SCENARIO_OUTLINE | TAGS)* ;
 
 scenarioOutline: tags? SCENARIO_OUTLINE scenarioDescription step* examples+ ;
 


### PR DESCRIPTION
### Description
I am seeing an issue where an empty background section will interpret the first scenario's tags as its scenario description. I noticed the tags definition was not included in the scenario description definition and including that has fixed the issue for me. 

- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
