### PR TITLE
Karate UI enhancement - threading implementation

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioExecutionUnit.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioExecutionUnit.java
@@ -43,6 +43,7 @@ public class ScenarioExecutionUnit implements Runnable {
     private final LogAppender appender;
     public final Logger logger;
     private final boolean async;
+    private boolean executed = false;
 
     private List<Step> steps;
     private Iterator<Step> iterator;
@@ -144,6 +145,7 @@ public class ScenarioExecutionUnit implements Runnable {
 
     // for karate ui
     public void reset(ScenarioContext context) {
+    	setExecuted(false);
         result.reset();
         actions = new StepActions(context);
     }
@@ -213,5 +215,13 @@ public class ScenarioExecutionUnit implements Runnable {
             }
         }
     }
+
+	public boolean isExecuted() {
+		return executed;
+	}
+
+	public void setExecuted(boolean executed) {
+		this.executed = executed;
+	}
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/ui/AppSession.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/AppSession.java
@@ -31,9 +31,14 @@ import com.intuit.karate.core.FeatureContext;
 import com.intuit.karate.core.FeatureExecutionUnit;
 import com.intuit.karate.core.FeatureParser;
 import com.intuit.karate.core.ScenarioExecutionUnit;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.List;
+
+import javafx.concurrent.Task;
 import javafx.scene.layout.BorderPane;
 
 /**
@@ -90,7 +95,18 @@ public class AppSession {
     }
 
     public void runAll() {
-    	scenarioPanels.forEach(scenarioPanel -> scenarioPanel.runAll());
+    	ExecutorService scenarioExecutorService = Executors.newSingleThreadExecutor();
+    	Task<Boolean> runAllTask = new Task<Boolean>() {
+			@Override
+			protected Boolean call() throws Exception {
+				for (ScenarioPanel scenarioPanel : scenarioPanels) {
+					setCurrentlyExecutingScenario(scenarioPanel.getScenarioExecutionUnit());
+					scenarioPanel.runAll(scenarioExecutorService);
+				}
+				return true;
+			}
+		};
+		scenarioExecutorService.submit(runAllTask);
     }
 
     public BorderPane getRootPane() {
@@ -99,6 +115,10 @@ public class AppSession {
 
     public FeatureOutlinePanel getFeatureOutlinePanel() {
         return featureOutlinePanel;
+    }
+    
+    public List<ScenarioPanel> getScenarioPanels() {
+        return scenarioPanels;
     }
 
     public void setCurrentlyExecutingScenario(ScenarioExecutionUnit unit) {

--- a/karate-core/src/main/java/com/intuit/karate/ui/FeatureOutlineCell.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/FeatureOutlineCell.java
@@ -49,7 +49,7 @@ public class FeatureOutlineCell extends ListCell<ScenarioExecutionUnit> {
         setTooltip(tooltip);
         if (item.result.isFailed()) {
             setStyle(STYLE_FAIL);
-        } else if (!item.result.getStepResults().isEmpty()) {
+        } else if (!item.result.getStepResults().isEmpty() && item.isExecuted()) {
             setStyle(STYLE_PASS);
         } else {
             setStyle("");

--- a/karate-core/src/main/java/com/intuit/karate/ui/FeatureOutlinePanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/FeatureOutlinePanel.java
@@ -25,8 +25,10 @@ package com.intuit.karate.ui;
 
 import com.intuit.karate.core.Feature;
 import com.intuit.karate.core.ScenarioExecutionUnit;
+
 import java.nio.file.Path;
 import java.util.List;
+
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
@@ -84,7 +86,9 @@ public class FeatureOutlinePanel extends BorderPane {
         listView = new ListView();
         listView.setItems(FXCollections.observableArrayList(units));
         listView.setCellFactory(lv -> new FeatureOutlineCell());
-        scrollPane.setContent(listView);
+        Platform.runLater(() -> {
+        	scrollPane.setContent(listView);
+        });
         listView.getSelectionModel()
                 .selectedIndexProperty()
                 .addListener((o, prev, value) -> session.setSelectedScenario(value.intValue()));        

--- a/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/StepPanel.java
@@ -149,6 +149,7 @@ public class StepPanel extends AnchorPane {
         } else {
             runButton.setStyle(STYLE_FAIL);
         }
+        enableRun();
     }
 
     public boolean run(boolean nonStop) {
@@ -173,5 +174,13 @@ public class StepPanel extends AnchorPane {
         scenarioPanel.refreshVars();
         return stepResult.isStopped();
     }
+
+	public void disableRun() {
+    	this.runButton.setDisable(true);
+	}
+    
+    public void enableRun() {
+    	this.runButton.setDisable(false);
+	}
 
 }


### PR DESCRIPTION

Attempt to implement a threading model so that step result reflects then and there instead of reflecting at the end of ALL Steps, same to work on scenario level as well.
Steps will be disabled on scenario level while execution - ( to avoid any interruption)

Current Behaviour:
 Click on **Run All steps** or **Run All Scenarios** step results will be only visible at the end and application will be behaving like hang/froze in between.

![karateui_enhancement_1](https://user-images.githubusercontent.com/26348282/52545412-547cd400-2ddd-11e9-9aa2-206d8ec9e696.gif)

After this change:
Step or scenario results will be updated instantly,

![karateui_enhancement_2](https://user-images.githubusercontent.com/26348282/52545454-a9b8e580-2ddd-11e9-9f8f-5fe768db8361.gif)



- Relevant Issues : https://github.com/intuit/karate/issues/675
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
