### PR TITLE
add alternative for finding JARs from classpath for JDK9+

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -482,7 +482,7 @@ public class FileUtils {
             } else {
                 String classpath = System.getProperty("java.class.path");
                 if (classpath != null && !classpath.isEmpty()) {
-                    String[] classpathEntries = classpath.split(System.getProperty("path.separator"));
+                    String[] classpathEntries = classpath.split(File.pathSeparator);
                     for (String classpathEntry : classpathEntries) {
                         if (classpathEntry.endsWith(".jar")) {
                             String entryWithForwardSlashes = classpathEntry.replaceAll("\\\\", "/");

--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -479,6 +479,19 @@ public class FileUtils {
                     URL url = new URL("jar:" + u + "!/");
                     list.add(url);
                 }
+            } else {
+                String classpath = System.getProperty("java.class.path");
+                if (classpath != null && !classpath.isEmpty()) {
+                    String[] classpathEntries = classpath.split(System.getProperty("path.separator"));
+                    for (String classpathEntry : classpathEntries) {
+                        if (classpathEntry.endsWith(".jar")) {
+                            String entryWithForwardSlashes = classpathEntry.replaceAll("\\\\", "/");
+                            boolean startsWithSlash = entryWithForwardSlashes.startsWith("/");
+                            URL url = new URL("jar:file:" + (startsWithSlash ? "" : "/") + entryWithForwardSlashes + "!/");
+                            list.add(url);
+                        }
+                    }
+                }
             }
             return list;
         } catch (Exception e) {


### PR DESCRIPTION
### Description

If the classloader is not of type URLClassLoader, attempt to parse the classpath JVM property for jars instead.

- Relevant Issues : #687 
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
