### PR TITLE
Fixed step panel disable issue when failing

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/ui/ScenarioPanel.java
+++ b/karate-core/src/main/java/com/intuit/karate/ui/ScenarioPanel.java
@@ -121,9 +121,10 @@ public class ScenarioPanel extends BorderPane {
         Task<Boolean> runAllTask = new Task<Boolean>() {
 			@Override
 			protected Boolean call() throws Exception {
-				stepPanels.forEach(step -> {step.disableRun();});
+				disableAllSteps();
 				for (StepPanel step : stepPanels) {
 					if (step.run(true)) {
+						enableAllSteps();
 		                break;
 		            }
 				}
@@ -144,9 +145,10 @@ public class ScenarioPanel extends BorderPane {
         Task<Boolean> runAllTask = new Task<Boolean>() {
 			@Override
 			protected Boolean call() throws Exception {
-				stepPanels.forEach(step -> {step.disableRun();});
+				disableAllSteps();
 				for (StepPanel step : stepPanels) {
 					if (step.run(true)) {
+						enableAllSteps();
 		                break;
 		            }
 				}
@@ -167,11 +169,10 @@ public class ScenarioPanel extends BorderPane {
     	Task<Boolean> runUptoTask = new Task<Boolean>() {
 			@Override
 			protected Boolean call() throws Exception {
-				stepPanels.forEach(step -> {step.disableRun();});
+				disableAllSteps();
 				for (StepPanel stepPanel : stepPanels) {
 		            int stepIndex = stepPanel.getIndex();
 		            StepResult sr = unit.result.getStepResult(stepPanel.getIndex());
-		            //StepResult sr = stepPanel.getScenarioExecutionUnit().result.getStepResult(stepPanel.getIndex());
 		            if (sr != null) {
 		                continue;
 		            }
@@ -179,7 +180,7 @@ public class ScenarioPanel extends BorderPane {
 		                break;
 		            }
 		        }
-				stepPanels.forEach(step -> {step.enableRun();});
+				enableAllSteps();
 				return true;
 			}
 		};
@@ -200,5 +201,13 @@ public class ScenarioPanel extends BorderPane {
         }
         session.getFeatureOutlinePanel().refresh();
     }
+    
+    public void enableAllSteps() {
+    	stepPanels.forEach(step -> {step.enableRun();});
+	}
+    
+    public void disableAllSteps() {
+    	stepPanels.forEach(step -> {step.disableRun();});
+	}
 
 }


### PR DESCRIPTION
After https://github.com/intuit/karate/pull/677, when steps fail in between running all steps it disables all following steps, this restricted user to continue debugging and forcing to reset, so changed to enable all steps after a run.

Before:
![karateui_step_fix](https://user-images.githubusercontent.com/26348282/53823815-80344980-3f98-11e9-9442-35bf8bdb2fa3.gif)

After:
![karateui_step_fix2](https://user-images.githubusercontent.com/26348282/53823825-86c2c100-3f98-11e9-92b7-a7efb224f343.gif)



- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
