### PR TITLE
Adding support for Windows paths

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -199,13 +199,11 @@ public class FileUtils {
     public static String toPackageQualifiedName(String path) {
         path = removePrefix(path);
         path = path.replace("/", "."); // for non windows path
-        if (isWindows()){ // for windows path
-            if (path.contains(":\\")) { // to remove driver letter and colon
-                path = removePrefix(path);
-            }
-            if (path.contains("\\")) { // for \ windows path
-                path = path.replace("\\",".");
-            }
+        if (path.contains(":\\")) { // to remove driver letter and colon
+            path = removePrefix(path);
+        }
+        if (path.contains("\\")) { // for \ windows path
+            path = path.replace("\\",".");
         }
         String  packagePath = path.replace("..", "");
         if (packagePath.startsWith(".")) {

--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -198,7 +198,19 @@ public class FileUtils {
 
     public static String toPackageQualifiedName(String path) {
         path = removePrefix(path);
-        String packagePath = path.replace("/", "."); // assumed to be already in non-windows form
+        path = path.replace("/", "."); // for non windows path
+        if (isWindows()){ // for windows path
+            if (path.contains(":\\")) { // to remove driver letter and colon
+                path = removePrefix(path);
+            }
+            if (path.contains("\\")) { // for \ windows path
+                path = path.replace("\\",".");
+            }
+        }
+        String  packagePath = path.replace("..", "");
+        if (packagePath.startsWith(".")) {
+            packagePath = packagePath.substring(1);
+        }
         if (packagePath.endsWith(".feature")) {
             packagePath = packagePath.substring(0, packagePath.length() - 8);
         }

--- a/karate-core/src/test/java/com/intuit/karate/FileUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/FileUtilsTest.java
@@ -28,6 +28,12 @@ public class FileUtilsTest {
         String path = "com/intuit/karate/cucumber/scenario.feature";
         String fixed = FileUtils.toPackageQualifiedName(path);
         assertEquals("com.intuit.karate.cucumber.scenario", fixed);
+        path = "file:C:\\Users\\Karate\\scenario.feature";
+        fixed = FileUtils.toPackageQualifiedName(path);
+        assertEquals("Users.Karate.scenario", fixed);
+        path = "file:../Karate/scenario.feature";
+        fixed = FileUtils.toPackageQualifiedName(path);
+        assertEquals("Karate.scenario", fixed);
     }
 
     @Test


### PR DESCRIPTION
Support to use absolute paths in Windows with `call` and `file:`

- Relevant Issues : https://github.com/intuit/karate/issues/695
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
