### PR TITLE
Don't use Lenient SSL if custom cert is specified #703

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -146,12 +146,17 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     builder = builder.loadKeyMaterial(keyStore, keyPassword);
                 }
                 sslContext = builder.build();
+                SSLConnectionSocketFactory socketFactory;
+                if (keyStore != null) {
+                    socketFactory = new SSLConnectionSocketFactory(sslContext, new NoopHostnameVerifier());
+                } else {
+                    socketFactory = new LenientSslConnectionSocketFactory(sslContext, new NoopHostnameVerifier());
+                }
+                clientBuilder.setSSLSocketFactory(socketFactory);
             } catch (Exception e) {
                 context.logger.error("ssl context init failed: {}", e.getMessage());
                 throw new RuntimeException(e);
             }
-            SSLConnectionSocketFactory socketFactory = new LenientSslConnectionSocketFactory(sslContext, new NoopHostnameVerifier());
-            clientBuilder.setSSLSocketFactory(socketFactory);
         }
         RequestConfig.Builder configBuilder = RequestConfig.custom()
                 .setCookieSpec(LenientCookieSpec.KARATE)

--- a/karate-apache/src/main/java/org/apache/http/conn/ssl/LenientSslConnectionSocketFactory.java
+++ b/karate-apache/src/main/java/org/apache/http/conn/ssl/LenientSslConnectionSocketFactory.java
@@ -43,6 +43,6 @@ public class LenientSslConnectionSocketFactory extends SSLConnectionSocketFactor
     @Override
     public Socket createLayeredSocket(Socket socket, String target, int port, HttpContext context) throws IOException {
         return super.createLayeredSocket(socket, "", port, context);
-    }       
+    }
     
 }


### PR DESCRIPTION
### Description

I didn't remove Lenient SSL connection, I only replaced it by the true SSL connection when a certificate is specified. SslTest is working.

- Relevant Issues : #703 
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
