### PR TITLE
Update global karate reference to always point to the current ScriptBridge

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1671,9 +1671,6 @@ public class Script {
     }
 
     public static ScriptValue evalFunctionCall(ScriptObjectMirror som, Object callArg, ScenarioContext context) {
-        // injects the 'karate' variable into the js function body
-        // also ensure that things like 'karate.get' operate on the latest variable state
-        som.setMember(ScriptBindings.KARATE, context.bindings.bridge);
         Object result;
         try {
             if (callArg != null) {


### PR DESCRIPTION
- Relevant Issues : #722
- Relevant PRs : -
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

As outlined in #722 it is possible for calls to show up weird in the report and I have taken most of the day to debug the issue. I have prepared a even simpler reproduer example for this: [callsmixed.zip](https://github.com/intuit/karate/files/3049767/callsmixed.zip)

I took a deep-dive into the karate calling code and was able to find the root issue of the problem I was having, but I am unsure about the solution.

First, the general problem is the following:

The root scenario (parent) calls a JS function defined in karate-config. The JS function calls another scenario (child). This scenario then calls another JS function defined in the config which calls a third scenario (grandchild).
Normally, the different scenario contexts are chained linearly from grandchild to child to parent via scenarioContext.parentContext.
However, in this particular case it does not work as expected, because the karate.call calls in karate-config are both performed on the same ScriptBridge (the one created by the parent.feature scenario). I did quite some debugging to find out what is happening and I could narrow it down the the Global object which is associated with the ScriptObjectMirror objects representing the js functions from karate-config. Somehow, this global object has a reference to karate which is always the first ScriptBridge object created. So now both child and grandchild are called as direct children of parent (instead of grandchild being a child of child).

The change in this PR is just a suggestion, I am happy for any input on how this can be solved more elegantly. What this change basically does is this:

When a new ScriptBridge is created then the reference to karate in the globals is updated to point to it. This also has to be done before each call and undone after the call has finished. This way, the current scope is always correct. 
I think there should be no harm with this change since it only affects the karate object and not any other globals. The only difference should be internal, i.e. how the call chains are being constructed. The tests all pass (although DemoTestParallel fails due to SSL errors, I think this must be a local issue I am having).
