### PR TITLE
Update karate version and add missing dependency to gradle build

### DIFF
--- a/karate-demo/build.gradle
+++ b/karate-demo/build.gradle
@@ -97,6 +97,6 @@ test {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = gradleVersionProperty
 }

--- a/karate-demo/build.gradle
+++ b/karate-demo/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.3.RELEASE'
         springVersion = '4.3.8.RELEASE'
         gradleVersionProperty = '4.1'
-        karateVersion = '0.9.0'
+        karateVersion = '0.9.2'
         masterThoughtVersion = '3.8.0'
         activeMqVersion = '5.15.2'
     }

--- a/karate-demo/build.gradle
+++ b/karate-demo/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-security'
     compile 'org.springframework:spring-jdbc:' + springVersion
+    compile 'org.springframework:spring-websocket:' + springVersion
     compile 'com.github.java-json-tools:json-schema-validator:2.2.8'
     compile 'commons-io:commons-io:2.5'
     runtime 'com.h2database:h2:1.4.196'


### PR DESCRIPTION
### Description

The `karate-demo` folder provides an outdated `build.gradle`. 
This PR  updates dependencies and make the gradle build build again.

After merging, another problem with the `com.intuit.karate.FileUtils#getFileRelativeTo` will be noticeable again.