### PR TITLE
#737 - relative resource loading with gradle

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -387,7 +387,6 @@ public class FileUtils {
     }
 
     public static Path getPathContaining(Class clazz) {
-
         String relative = packageAsPath(clazz);
         URL url = clazz.getClassLoader().getResource(relative);
         return getPathFor(url, null);
@@ -404,7 +403,6 @@ public class FileUtils {
     }
 
     public static File getFileRelativeTo(Class clazz, String path) {
-
         Path dirPath = getPathContaining(clazz);
         File file = new File(dirPath + File.separator + path);
         if (file.exists()) {

--- a/karate-core/src/main/java/com/intuit/karate/FileUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/FileUtils.java
@@ -387,18 +387,35 @@ public class FileUtils {
     }
 
     public static Path getPathContaining(Class clazz) {
+
+        String relative = packageAsPath(clazz);
+        URL url = clazz.getClassLoader().getResource(relative);
+        return getPathFor(url, null);
+    }
+
+    private static String packageAsPath(Class clazz) {
+
         Package p = clazz.getPackage();
         String relative = "";
         if (p != null) {
             relative = p.getName().replace('.', '/');
         }
-        URL url = clazz.getClassLoader().getResource(relative);
-        return getPathFor(url, null);
+        return relative;
     }
 
     public static File getFileRelativeTo(Class clazz, String path) {
+
         Path dirPath = getPathContaining(clazz);
-        return new File(dirPath + File.separator + path);
+        File file = new File(dirPath + File.separator + path);
+        if (file.exists()) {
+            return file;
+        }
+        try {
+            URL relativePath = clazz.getClassLoader().getResource(packageAsPath(clazz) + File.separator + path);
+            return Paths.get(relativePath.toURI()).toFile();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(String.format("Cannot resolve path '%s' relative to class '%s' ", path, clazz.getName()), e);
+        }
     }
 
     public static String toRelativeClassPath(Class clazz) {
@@ -593,7 +610,7 @@ public class FileUtils {
         }
         String command = System.getProperty("sun.java.command", "");
         return command.contains("org.gradle.") ? "build" : "target";
-    }    
+    }
 
     public static enum Platform {
         WINDOWS,


### PR DESCRIPTION
Maven copies resource files next to class files. Therefore, the relative lookup of resource files works with this setup.

Gradle copies resource files into a separate resource folder. This breaks the relative file lookup, because it's expected that resource files resides next to the class files.

This PR adds a fallback to the relative file lookup. When a file cannot be found, a classpath lookup tries to find the resource. 

I didn't add an extra test for this fallback, because it's difficult to test the behavior in a maven environment. 

Maybe a separate gradle module to test karate under gradle would be an option.