### PR TITLE
Add unit tests for FileUtils, StringUtils and Tag classes

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/FileUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/FileUtilsTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.intuit.karate;
 
 import com.intuit.karate.core.Feature;
@@ -23,6 +46,102 @@ import org.slf4j.LoggerFactory;
 public class FileUtilsTest {
 
     private static final Logger logger = LoggerFactory.getLogger(FileUtilsTest.class);
+
+    @Test
+    public void testIsClassPath() {
+        assertFalse(FileUtils.isClassPath("foo/bar/baz"));
+        assertTrue(FileUtils.isClassPath("classpath:foo/bar/baz"));
+    }
+
+    @Test
+    public void testIsFilePath() {
+        assertFalse(FileUtils.isFilePath("foo/bar/baz"));
+        assertTrue(FileUtils.isFilePath("file:/foo/bar/baz"));
+    }
+
+    @Test
+    public void testIsThisPath() {
+        assertFalse(FileUtils.isThisPath("foo/bar/baz"));
+        assertTrue(FileUtils.isThisPath("this:/foo/bar/baz"));
+    }
+
+    @Test
+    public void testIsJsonFile() {
+        assertFalse(FileUtils.isJsonFile("foo.txt"));
+        assertTrue(FileUtils.isJsonFile("foo.json"));
+    }
+
+    @Test
+    public void testIsJavaScriptFile() {
+        assertFalse(FileUtils.isJavaScriptFile("foo.txt"));
+        assertTrue(FileUtils.isJavaScriptFile("foo.js"));
+    }
+
+    @Test
+    public void testIsYamlFile() {
+        assertFalse(FileUtils.isYamlFile("foo.txt"));
+        assertTrue(FileUtils.isYamlFile("foo.yaml"));
+        assertTrue(FileUtils.isYamlFile("foo.yml"));
+    }
+
+    @Test
+    public void testIsXmlFile() {
+        assertFalse(FileUtils.isXmlFile("foo.txt"));
+        assertTrue(FileUtils.isXmlFile("foo.xml"));
+    }
+
+    @Test
+    public void testIsTextFile() {
+        assertFalse(FileUtils.isTextFile("foo.xml"));
+        assertTrue(FileUtils.isTextFile("foo.txt"));
+    }
+
+    @Test
+    public void testIsCsvFile() {
+        assertFalse(FileUtils.isCsvFile("foo.txt"));
+        assertTrue(FileUtils.isCsvFile("foo.csv"));
+    }
+
+    @Test
+    public void testIsGraphQlFile() {
+        assertFalse(FileUtils.isGraphQlFile("foo.txt"));
+        assertTrue(FileUtils.isGraphQlFile("foo.graphql"));
+        assertTrue(FileUtils.isGraphQlFile("foo.gql"));
+    }
+
+    @Test
+    public void testIsFeatureFile() {
+        assertFalse(FileUtils.isFeatureFile("foo.txt"));
+        assertTrue(FileUtils.isFeatureFile("foo.feature"));
+    }
+
+    @Test
+    public void testRemovePrefix() {
+        assertEquals("baz", FileUtils.removePrefix("foobar:baz"));
+        assertEquals("foobarbaz", FileUtils.removePrefix("foobarbaz"));
+
+        assertNull(FileUtils.removePrefix(null));
+    }
+
+    @Test
+    public void testToStringBytes() {
+        final byte[] bytes = { 102, 111, 111, 98, 97, 114 };
+        assertEquals("foobar", FileUtils.toString(bytes));
+        assertNull(FileUtils.toString((byte[])null));
+    }
+
+    @Test
+    public void testToBytesString() {
+        final byte[] bytes = { 102, 111, 111, 98, 97, 114 };
+        assertArrayEquals(bytes, FileUtils.toBytes("foobar"));
+        assertNull(FileUtils.toBytes((String)null));
+    }
+
+    @Test
+    public void testReplaceFileExtension() {
+        assertEquals("foo.bar", FileUtils.replaceFileExtension("foo.txt", "bar"));
+        assertEquals("foo.baz", FileUtils.replaceFileExtension("foo", "baz"));
+    }
 
     @Test
     public void testWindowsFileNames() {

--- a/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
@@ -25,7 +25,13 @@ package com.intuit.karate;
 
 import java.util.Arrays;
 import java.util.List;
+
+import com.intuit.karate.StringUtils.Pair;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import static org.junit.Assert.*;
 
 /**
@@ -33,6 +39,33 @@ import static org.junit.Assert.*;
  * @author pthomas3
  */
 public class StringUtilsTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testPair() {
+        assertEquals(new Pair("foo", "bar"), StringUtils.pair("foo", "bar"));
+    }
+
+    @Test
+    public void testTrimToEmpty() {
+        assertEquals("", StringUtils.trimToEmpty(null));
+        assertEquals("foo", StringUtils.trimToEmpty("   foo   "));
+    }
+
+    @Test
+    public void testTrimToNull() {
+        assertNull(StringUtils.trimToNull(null));
+        assertNull(StringUtils.trimToNull("   "));
+        assertEquals("foo", StringUtils.trimToNull("   foo   "));
+    }
+
+    @Test
+    public void testRepeat() {
+        assertEquals("\u0000", StringUtils.repeat('\u0000', 1));
+        assertEquals("aaaaa", StringUtils.repeat('a', 5));
+        assertEquals("", StringUtils.repeat('\u0000', 0));
+    }
 
     @Test
     public void testSplit() {
@@ -77,4 +110,49 @@ public class StringUtilsTest {
         assertEquals("function(){}", StringUtils.fixJavaScriptFunction("function fn(){}"));
     }
 
+    public void testIsBlank() {
+        assertTrue(StringUtils.isBlank(""));
+        assertTrue(StringUtils.isBlank(null));
+        assertFalse(StringUtils.isBlank("foo"));
+    }
+
+    @Test
+    public void testToIdString() {
+        assertEquals("foo-bar", StringUtils.toIdString("foo_bar"));
+        thrown.expect(NullPointerException.class);
+        StringUtils.toIdString(null);
+        // Method is not expected to return due to exception thrown
+    }
+
+    @Test
+    public void testSplitByFirstLineFeed() {
+        assertEquals(new Pair("", ""),
+                StringUtils.splitByFirstLineFeed(null));
+        assertEquals(new Pair("foo", ""),
+                StringUtils.splitByFirstLineFeed("foo"));
+        assertEquals(new Pair("foo", "bar"),
+                StringUtils.splitByFirstLineFeed("foo\nbar"));
+    }
+
+    @Test
+    public void testToStringLines() {
+        List<String> expected = Arrays.asList("foo", "bar");
+        assertEquals(expected, StringUtils.toStringLines("foo\nbar\n"));
+    }
+
+    @Test
+    public void testCountLineFeeds() {
+        assertEquals(2, StringUtils.countLineFeeds("foo\nbar\n"));
+        assertEquals(0, StringUtils.countLineFeeds("foobar"));
+    }
+
+    @Test
+    public void testWrappedLinesEstimate() {
+        assertEquals(6,
+                StringUtils.wrappedLinesEstimate("foobarbazfoobarbaz", 3));
+        assertEquals(1,
+                StringUtils.wrappedLinesEstimate("foobarbazfoobarbaz", 20));
+        assertEquals(0,
+                StringUtils.wrappedLinesEstimate("", 2));
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/TagTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/TagTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.intuit.karate.core;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TagTest {
+
+  final Tag tag = new Tag(5, "@foo=bar,baz");
+
+  @Test
+  public void testGetLine() {
+    assertEquals(5, tag.getLine());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("foo=bar,baz", tag.getText());
+  }
+
+  @Test
+  public void testGetName() {
+    assertEquals("foo", tag.getName());
+  }
+
+  @Test
+  public void testGetValues() {
+    assertEquals(Arrays.asList("bar", "baz"), tag.getValues());
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals("@foo=bar,baz", new Tag(5, "@foo=bar,baz").toString());
+    assertEquals("@foo=", new Tag(5, "@foo=").toString());
+    assertEquals("@foobar,baz", new Tag(5, "@foobar,baz").toString());
+  }
+
+  @Test
+  public void testHashcode() {
+    assertEquals(894422763, tag.hashCode());
+  }
+
+  @Test
+  public void testEquals() {
+    assertTrue(tag.equals(tag));
+    assertFalse(tag.equals(null));
+    assertFalse(tag.equals(new Tag(0, "@baz=bar,foo")));
+    assertFalse(tag.equals("foo"));
+  }
+}


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #726 #812
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

I've added unit tests, written with the help of [Diffblue Cover](https://www.diffblue.com/opensource) for the following classes:
com.intuit.karate.FileUtils
com.intuit.karate.StringUtils
com.intuit.karate.core.Tag

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be happy to look at other classes that you consider important