### PR TITLE
Handle Karate tests in a BootJar

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/StepActions.java
+++ b/karate-core/src/main/java/com/intuit/karate/StepActions.java
@@ -50,7 +50,11 @@ public class StepActions implements Actions {
     public final ScenarioContext context;
 
     public StepActions(FeatureContext featureContext, CallContext callContext, Scenario scenario, Logger logger) {
-        context = new ScenarioContext(featureContext, callContext, scenario, logger);
+        this(featureContext, callContext, null, scenario, logger);
+    }
+
+    public StepActions(FeatureContext featureContext, CallContext callContext, ClassLoader classLoader, Scenario scenario, Logger logger) {
+        context = new ScenarioContext(featureContext, callContext, classLoader, scenario, logger);
     }
 
     public StepActions(ScenarioContext context) {
@@ -367,25 +371,24 @@ public class StepActions implements Actions {
     public void evalDocstring(String exp) {
         context.eval(exp);
     }
-    
+
     @Override
     @When("^([\\w]+)([^\\s^\\w])(.+)")
     public void eval(String name, String dotOrParen, String expression) {
         context.eval(name + dotOrParen + expression);
-    } 
-    
+    }
+
     @Override
     @When("^if (.+)")
     public void evalIf(String exp) {
         context.eval("if " + exp);
-    }    
-
+    }
     //==========================================================================
     //
+
     @Override
     @When("^driver (.+)")
     public void driver(String expression) {
         context.driver(expression);
     }
-
 }

--- a/karate-core/src/main/java/com/intuit/karate/core/ExecutionContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ExecutionContext.java
@@ -44,16 +44,23 @@ public class ExecutionContext {
     public final FeatureResult result;
     public final Consumer<Runnable> system;
     public final ExecutorService scenarioExecutor;
+    public final ClassLoader classLoader;
 
     private final File reportDir;
 
     public ExecutionContext(long startTime, FeatureContext featureContext, CallContext callContext, String reportDirString,
-            Consumer<Runnable> system, ExecutorService scenarioExecutor) {
+                            Consumer<Runnable> system, ExecutorService scenarioExecutor) {
+        this(startTime, featureContext, callContext, reportDirString, system, scenarioExecutor, null);
+    }
+
+    public ExecutionContext(long startTime, FeatureContext featureContext, CallContext callContext, String reportDirString,
+                            Consumer<Runnable> system, ExecutorService scenarioExecutor, ClassLoader classLoader) {
         this.scenarioExecutor = scenarioExecutor;
         this.startTime = startTime;
         result = new FeatureResult(featureContext.feature);
         this.featureContext = featureContext;
         this.callContext = callContext;
+        this.classLoader = classLoader;
         if (callContext.perfMode) {
             reportDir = null;
         } else {

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureContext.java
@@ -28,6 +28,7 @@ import com.intuit.karate.ScriptBindings;
 import com.intuit.karate.StringUtils;
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,8 +57,8 @@ public class FeatureContext {
         this.env = getEnv(envString);        
         this.tagSelector = tagSelector;
         this.feature = feature;
-        this.callCache = new HashMap(1);       
-        this.parentPath = workingDir == null ? feature.getPath().getParent() : workingDir.toPath();
+        this.callCache = new HashMap(1);
+        this.parentPath = workingDir == null ? Paths.get(feature.getRelativePath()).getParent() : workingDir.toPath();
         this.packageQualifiedName = workingDir == null ? feature.getResource().getPackageQualifiedName() : "";
     }
     

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
@@ -47,11 +47,12 @@ import com.intuit.karate.http.HttpUtils;
 import com.intuit.karate.http.MultiPartItem;
 import com.intuit.karate.driver.Driver;
 import com.intuit.karate.driver.DriverOptions;
-import com.intuit.karate.driver.Keys;
 import com.intuit.karate.netty.WebSocketClient;
 import com.intuit.karate.netty.WebSocketOptions;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,6 +84,7 @@ public class ScenarioContext {
     public final Collection<ExecutionHook> executionHooks;
     public final boolean perfMode;
     public final ScenarioInfo scenarioInfo;
+    private final ClassLoader classLoader;
 
     public final Function<String, Object> read = s -> {
         ScriptValue sv = FileUtils.readFile(s, this);
@@ -196,6 +198,14 @@ public class ScenarioContext {
         return callable;
     }
 
+    public URL getResource(String name) {
+        return classLoader.getResource(name);
+    }
+
+    public InputStream getResourceAsStream(String name) {
+        return classLoader.getResourceAsStream(name);
+    }
+
     public void updateConfigCookies(Map<String, Cookie> cookies) {
         if (cookies == null) {
             return;
@@ -214,7 +224,12 @@ public class ScenarioContext {
     }
 
     public ScenarioContext(FeatureContext featureContext, CallContext call, Scenario scenario, Logger logger) {
+        this(featureContext, call, null, scenario, logger);
+    }
+
+    public ScenarioContext(FeatureContext featureContext, CallContext call, ClassLoader classLoader, Scenario scenario, Logger logger) {
         this.featureContext = featureContext;
+        this.classLoader = classLoader == null ? resolveClassLoader(call) : classLoader;
         if (logger == null) { // ensure this.logger is set properly
             logger = new Logger();
         }
@@ -303,6 +318,13 @@ public class ScenarioContext {
         logger.trace("karate context init - initial properties: {}", vars);
     }
 
+    private static ClassLoader resolveClassLoader(CallContext call) {
+        if (call.context == null) {
+            return Thread.currentThread().getContextClassLoader();
+        }
+        return call.context.classLoader;
+    }
+
     public ScenarioContext copy(ScenarioInfo info, Logger logger) {
         return new ScenarioContext(this, info, logger);
     }
@@ -313,6 +335,7 @@ public class ScenarioContext {
 
     private ScenarioContext(ScenarioContext sc, ScenarioInfo info, Logger logger) {
         featureContext = sc.featureContext;
+        classLoader = sc.classLoader;
         this.logger = logger;
         callDepth = sc.callDepth;
         reuseParentContext = sc.reuseParentContext;
@@ -858,7 +881,7 @@ public class ScenarioContext {
     }
 
     // driver ==================================================================       
-    //    
+    //
     private void put(String name, Consumer<String> value) {
         bindings.putAdditionalVariable(name, value);
     }

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioExecutionUnit.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioExecutionUnit.java
@@ -139,7 +139,7 @@ public class ScenarioExecutionUnit implements Runnable {
             // karate-config.js will be processed here 
             // when the script-context constructor is called
             try {
-                actions = new StepActions(exec.featureContext, exec.callContext, scenario, logger);
+                actions = new StepActions(exec.featureContext, exec.callContext, exec.classLoader, scenario, logger);
             } catch (Exception e) {
                 initFailed = true;
                 result.addError("scenario init failed", e);

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClient.java
@@ -265,7 +265,7 @@ public abstract class HttpClient<T> {
             if (config.getClientClass() != null) {
                 className = config.getClientClass();
             } else {
-                InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(KARATE_HTTP_PROPERTIES);
+                InputStream is = context.getResourceAsStream(KARATE_HTTP_PROPERTIES);
                 if (is == null) {
                     String msg = KARATE_HTTP_PROPERTIES + " not found";
                     throw new RuntimeException(msg);

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
@@ -60,7 +60,7 @@ public class HttpUtils {
         }
         try {
             KeyStore keyStore = KeyStore.getInstance(type);
-            InputStream is = FileUtils.getFileStream(trustStoreFile, context);
+            InputStream is = FileUtils.readFileAsStream(trustStoreFile, context);
             keyStore.load(is, passwordChars);
             context.logger.debug("key store key count for {}: {}", trustStoreFile, keyStore.size());
             return keyStore;

--- a/karate-junit4/pom.xml
+++ b/karate-junit4/pom.xml
@@ -38,7 +38,19 @@
             <artifactId>cucumber-reporting</artifactId>
             <version>${cucumber.reporting.version}</version>
             <scope>test</scope>
-        </dependency>		
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/files/BootJarLoadingTest.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/files/BootJarLoadingTest.java
@@ -1,0 +1,123 @@
+package com.intuit.karate.junit4.files;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import com.intuit.karate.Resource;
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
+import com.intuit.karate.core.Tags;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.boot.loader.JarLauncher;
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.boot.loader.archive.JarFileArchive;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+import static java.util.stream.Collectors.*;
+import static org.junit.Assert.*;
+import static org.springframework.core.io.support.ResourcePatternResolver.*;
+
+/**
+ * Tests on Karate's runner applied on resources bundled in a bootJar.
+ */
+public class BootJarLoadingTest {
+
+    private static ClassLoader classLoader;
+    
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        classLoader = getJarClassLoader();
+    }
+
+    @Test
+    public void testRunningFromBootJar() {
+        // mimics how a Spring Boot application sets its class loader into the thread's context
+        Thread.currentThread().setContextClassLoader(classLoader);
+        SpringBootResourceLoader springBootResourceLoader = new SpringBootResourceLoader(classLoader, "com/karate/jartest");
+        List<Resource> resources = springBootResourceLoader.asKarateResources();
+        assertEquals(6, resources.size());
+
+        Results results = Runner.parallel(null, resources, 1, "target/surefire-reports");
+
+        assertEquals(6, results.getFeatureCount());
+        assertEquals(6, results.getPassCount());
+    }
+
+    private static ClassLoader getJarClassLoader() throws Exception {
+        File jar = new File("../karate-core/src/test/resources/karate-bootjar-test.jar");
+        assertTrue(jar.exists());
+        return new IntegrationTestJarLauncher(new JarFileArchive(jar)).createClassLoader();
+    }
+
+    /**
+     * Custom {@link JarLauncher} used for retrieving a resource in a bootJar.
+     */
+    static class IntegrationTestJarLauncher extends JarLauncher {
+
+        IntegrationTestJarLauncher(Archive archive) {
+            super(archive);
+        }
+
+        ClassLoader createClassLoader() throws Exception {
+            return createClassLoader(getClassPathArchives());
+        }
+    }
+
+    /**
+     * Loads feature files using the provided ClassLoader
+     */
+    private static class SpringBootResourceLoader {
+
+        private final org.springframework.core.io.Resource[] resources;
+
+        SpringBootResourceLoader(ClassLoader cl, String packagePath) {
+            String locationPattern = CLASSPATH_ALL_URL_PREFIX + "**/" + packagePath + "/**/*.feature";
+            ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(cl);
+            try {
+                resources = resolver.getResources(locationPattern);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        List<Resource> asKarateResources() {
+            return Arrays.stream(resources)
+                    .map(SpringBootResourceLoader::toSpringBootResource)
+                    .collect(toList());
+        }
+
+        private static SpringBootResource toSpringBootResource(org.springframework.core.io.Resource resource) {
+            try {
+                return new SpringBootResource(resource);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    /**
+     * An extension of Karate's {@link Resource} handling a Spring Boot's resource.
+     */
+    private static class SpringBootResource extends Resource {
+
+        private static final String BOOT_INF_CLASS_DIRECTORY = "BOOT-INF/classes!/";
+
+        SpringBootResource(org.springframework.core.io.Resource resource) throws IOException {
+            super(resource.getURL(), getBootClassSubstring(resource.getURL().getPath()), -1);
+        }
+
+        private static String getBootClassSubstring(String path) {
+            // The filePath will always contain a Spring-Boot-specific directory structure here,
+            // since at this point we always expect to be inside a bundled (a bootJar) Spring Boot application
+            return path.substring(path.indexOf(BOOT_INF_CLASS_DIRECTORY) + BOOT_INF_CLASS_DIRECTORY.length());
+        }
+    }
+}

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/files/JarLoadingTest.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/files/JarLoadingTest.java
@@ -55,6 +55,7 @@ public class JarLoadingTest {
         String relativePath = FileUtils.toRelativeClassPath(path, cl);
         assertEquals("classpath:demo/jar1/caller.feature", relativePath);
         Feature feature = FeatureParser.parse(resource);
+        Thread.currentThread().setContextClassLoader(cl);
         Map<String, Object> map = Runner.runFeature(feature, null, false);
         assertEquals(true, map.get("success"));
     }


### PR DESCRIPTION
- Relevant Issues : https://github.com/intuit/karate/issues/751
- Type of change : Bug fix for existing feature

Hello, so after some investigation here's half (or maybe 2/3) of the solution to launch Karate tests inside a jar packaged by Spring Boot.

Here are the important changes brought by this PR:
- In the `Runner`, the `featureExecutor` will be initialized using a `privilegedThreadFactory()` in order to have access to the invoking thread's `contextClassLoader`. Spring Boot sets its own `ClassLoader` in the thread's context, and this `ClassLoader` is very useful in retrieving packaged feature files. Each `ExecutionContext` retrieves the `contextClassLoader`, which is then passed down to each `ScenarioContext`.
- Across scenarios, this ClassLoader might be null. This is handled by passing the initial one through a `CallContext`. When resolving a scenario we cannot retrieve the Spring Boot's ClassLoader by using `Thread.currentThread().getContextClassLoader()` because we are in a Thread managed by a ForkJoinPool (the executor `scenarioExecutor` in `Runner`).
- This ClassLoader retrieves the `karate-http.properties`
- The ClassLoader is used in the `FileUtils` to create a `Resource` wrapping a `URL`. This `URL` is a good pointer to the packaged files.
- The test class `BootJarLoadingTest` uses the newly added jar `karate-bootjar-test.jar` to test the new modifications.

I previously said "half of the solution" because at the moment `this` and relative path resolution mechanisms do not work, such as `call read('this:a.feature')` and `call read('../a.feature')`. Also, the Karate's `Resource` class should probably be modified in order to be more generic in the resources it can handle (see `BootJarLoadingTest` to see the working solution we've been using since we started using Karate with Spring Boot). I'm currently working on a solution for that.