### PR TITLE
Appium screen recording

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -146,6 +146,13 @@
     | <a href="#screenshotfull"><code>screenshotFull()</code></a>
   </td> 
 </tr>
+<tr>
+  <th>Appium</th>
+  <td>
+      <a href="#screen-recording">screen recording</a>
+    | <a href="#hideKeyboard"><code>hideKeyboard()</code></a>
+  </td> 
+</tr>
 </table>
 
 ## Capabilities
@@ -1334,3 +1341,19 @@ Only supported for driver type [`chrome`](#driver-types). See [Chrome Java API](
 
 ## `pdf()`
 Only supported for driver type [`chrome`](#driver-types). See [Chrome Java API](#chrome-java-api).
+
+# Appium
+
+## `screen recording`
+Only supported for driver type [`android | ios`](#driver-types).
+```cucumber
+* driver.startRecordingScreen()
+# test
+* driver.saveRecordingScreen("invoice.mp4",true)
+```
+above example would save the file and perform "auto-embedding" to HTML report.
+
+you can also use `startRecordingScreen()` and `stopRecordingScreen()`, both takes recording options as JSON input.
+
+## `hideKeyboard()`
+Only supported for driver type [`android | ios`](#driver-types), for hide soft keyboard.

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -149,7 +149,7 @@
 <tr>
   <th>Appium</th>
   <td>
-      <a href="#screen-recording">screen recording</a>
+      <a href="#screen-recording">Screen Recording</a>
     | <a href="#hideKeyboard"><code>hideKeyboard()</code></a>
   </td> 
 </tr>
@@ -1344,7 +1344,7 @@ Only supported for driver type [`chrome`](#driver-types). See [Chrome Java API](
 
 # Appium
 
-## `screen recording`
+## `Screen Recording`
 Only supported for driver type [`android | ios`](#driver-types).
 ```cucumber
 * driver.startRecordingScreen()

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
@@ -878,10 +878,7 @@ public class ScenarioContext {
         Embed embed = new Embed();
         embed.setBytes(bytes);
         embed.setMimeType(contentType);
-        if (prevEmbeds == null) {
-            prevEmbeds = new ArrayList();
-        }
-        prevEmbeds.add(embed);
+        embed(embed);
     }
 
     public void embed(Embed embed) {

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
@@ -884,6 +884,13 @@ public class ScenarioContext {
         prevEmbeds.add(embed);
     }
 
+    public void embed(Embed embed) {
+        if (prevEmbeds == null) {
+            prevEmbeds = new ArrayList();
+        }
+        prevEmbeds.add(embed);
+    }
+
     public WebSocketClient webSocket(WebSocketOptions options) {
         WebSocketClient webSocketClient = new WebSocketClient(options, logger);
         if (webSocketClients == null) {

--- a/karate-core/src/main/java/com/intuit/karate/driver/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/AppiumDriver.java
@@ -24,7 +24,14 @@
 package com.intuit.karate.driver;
 
 import com.intuit.karate.*;
+import com.intuit.karate.core.Embed;
 import com.intuit.karate.shell.Command;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author babusekaran
@@ -82,6 +89,51 @@ public abstract class AppiumDriver extends WebDriver {
 
     public void hideKeyboard() {
         http.path("appium", "device", "hide_keyboard").post("{}");
+    }
+
+    public String startRecordingScreen() {
+        return http.path("appium", "start_recording_screen").post("{}").jsonPath("$.value").asString();
+    }
+
+    public String startRecordingScreen(Map<String, Object> payload) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("options",payload);
+        return http.path("appium", "start_recording_screen").post(options).jsonPath("$.value").asString();
+    }
+
+    public String stopRecordingScreen() {
+        return http.path("appium", "stop_recording_screen").post("{}").jsonPath("$.value").asString();
+    }
+
+    public String stopRecordingScreen(Map<String, Object> payload) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("options",payload);
+        return http.path("appium", "stop_recording_screen").post(options).jsonPath("$.value").asString();
+    }
+
+    public void saveRecordingScreen(String fileName, boolean embed) {
+        String videoTemp = stopRecordingScreen();
+        byte[] bytes = Base64.getDecoder().decode(videoTemp);
+        File src = new File(fileName);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(src.getAbsolutePath())){
+            fileOutputStream.write(bytes);
+        }
+        catch (Exception e){
+            logger.error("error while saveRecordingScreen {}", e.getMessage());
+        }
+        if (embed){
+            if (src.exists()) {
+                String path = FileUtils.getBuildDir() + File.separator
+                        + "cucumber-html-reports" + File.separator + System.currentTimeMillis() + ".mp4";
+                File dest = new File(path);
+                FileUtils.copy(src, dest);
+                options.embedMp4Video(Embed.forVideoFile(dest.getName()));
+            }
+        }
+    }
+
+    public void saveRecordingScreen(String fileName) {
+        saveRecordingScreen(fileName,false);
     }
 
     @Override

--- a/karate-core/src/main/java/com/intuit/karate/driver/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/AppiumDriver.java
@@ -127,7 +127,7 @@ public abstract class AppiumDriver extends WebDriver {
                         + "cucumber-html-reports" + File.separator + System.currentTimeMillis() + ".mp4";
                 File dest = new File(path);
                 FileUtils.copy(src, dest);
-                options.embedMp4Video(Embed.forVideoFile(dest.getName()));
+                options.embedContent(Embed.forVideoFile(dest.getName()));
             }
         }
     }

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -482,7 +482,7 @@ public class DriverOptions {
         }
     }
 
-    public void embedMp4Video(Embed embed) {
+    public void embedContent(Embed embed) {
         if (context != null) {
             context.embed(embed);
         }

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -27,6 +27,7 @@ import com.intuit.karate.Config;
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.LogAppender;
 import com.intuit.karate.Logger;
+import com.intuit.karate.core.Embed;
 import com.intuit.karate.core.ScenarioContext;
 import com.intuit.karate.driver.android.AndroidDriver;
 import com.intuit.karate.driver.chrome.Chrome;
@@ -478,6 +479,12 @@ public class DriverOptions {
     public void embedPngImage(byte[] bytes) {
         if (context != null) { // can be null if chrome java api
             context.embed(bytes, "image/png");
+        }
+    }
+
+    public void embedMp4Video(Embed embed) {
+        if (context != null) {
+            context.embed(embed);
         }
     }
 


### PR DESCRIPTION
As requested in https://stackoverflow.com/q/57889035/8615449 

- added `startRecordingScreen()` and `stopRecordingScreen()` from appium
- Introduced a `saveRecordingScreen()` function to appium driver for directly save screen recording and embed to HTML.

```
* driver.startRecordingScreen()
# test
* driver.saveRecordingScreen("calc.mp4",true)
```
 
[cucumber-html-reports.zip](https://github.com/intuit/karate/files/3617245/cucumber-html-reports.zip)


- Relevant Issues : https://github.com/intuit/karate/issues/743
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
