### PR TITLE
multipart/form-data works via REST client but fails in Karate tests #797

### DIFF
--- a/karate-mock-servlet/src/main/java/com/intuit/karate/mock/servlet/MockMultiPart.java
+++ b/karate-mock-servlet/src/main/java/com/intuit/karate/mock/servlet/MockMultiPart.java
@@ -110,10 +110,14 @@ public class MockMultiPart implements Part {
         
     }
 
-    @Override
-    public String getHeader(String string) {
-        return headers.get(string);
-    }
+	@Override
+	public String getHeader(String string) {
+		/**
+		 * support spring boot 2 StandardMultipartHttpServletRequest implementation to
+		 * give CONTENT_DISPOSITION header details.
+		 */
+		return headers.getOrDefault(string, headers.get(string.toLowerCase()));
+	}
 
     @Override
     public Collection<String> getHeaders(String string) {

--- a/karate-mock-servlet/src/test/java/com/intuit/karate/mock/servlet/test/MockMultiPartTest.java
+++ b/karate-mock-servlet/src/test/java/com/intuit/karate/mock/servlet/test/MockMultiPartTest.java
@@ -1,0 +1,48 @@
+package com.intuit.karate.mock.servlet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+
+import com.intuit.karate.ScriptValue;
+import com.intuit.karate.http.MultiPartItem;
+import com.intuit.karate.mock.servlet.MockMultiPart;
+
+/**
+ * @author nsehgal
+ * 
+ *         Test for different StandardMultipartHttpServletRequest implementation
+ *         in spring. Below test checks both the implementation should return
+ *         the CONTENT_DISPOSITION header details when asked via getHeader().
+ *
+ */
+public class MockMultiPartTest {
+
+	private MockMultiPart mockMultiPart = null;
+
+	private static final String CONTENT_DISPOSITION = "content-disposition";
+
+	@Before
+	public void init() {
+		ScriptValue NULL = new ScriptValue(null);
+		MultiPartItem item = new MultiPartItem("file", NULL);
+		item.setContentType("text/csv");
+		item.setFilename("test.csv");
+		mockMultiPart = new MockMultiPart(item);
+	}
+
+	@Test
+	public void testSpring2MultipartHeader() {
+		String headerValue = mockMultiPart.getHeader(HttpHeaders.CONTENT_DISPOSITION);
+		Assert.assertNotNull(headerValue);
+		Assert.assertEquals("form-data; filename=\"test.csv\"; name=\"file\"", headerValue);
+	}
+
+	@Test
+	public void testSpring1MultipartHeader() {
+		String headerValue = mockMultiPart.getHeader(CONTENT_DISPOSITION);
+		Assert.assertNotNull(headerValue);
+		Assert.assertEquals("form-data; filename=\"test.csv\"; name=\"file\"", headerValue);
+	}
+}


### PR DESCRIPTION
@ptrthomas  
Implementation for resolving MockHttpClient multipart file upload issue.
Issue: https://github.com/intuit/karate/issues/797

Issue was with StandardMultipartHttpServletRequest implementation that in spring-web.Which has started using different case for CONTENT_DISPOSITION header in the request due to which it throws NLP exception.

Have added a fallback in case of header not found to check with lowercase header value that we have in MockMultiPart.

Will work both in spring boot 1 and 2 dependency.

Verified the same in the demo project shared in the issue.

Before change Test case report:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/16278936/66154530-46651780-e63b-11e9-8c96-3b84a526e011.png">

After Change Test case report:

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/16278936/66154550-5846ba80-e63b-11e9-9c46-e0b72ea4804a.png">
