### PR TITLE
HACKTOBERFEST-match != fails with two integers

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1546,7 +1546,9 @@ public class Script {
                 }
             }
         } else if (!expObject.equals(actObject)) { // same data type, but not equal
-            if (matchType != MatchType.NOT_EQUALS) {
+            if (matchType == MatchType.NOT_EQUALS) {
+                return AssertionResult.PASS;
+            } else {
                 return matchFailed(matchType, path, actObject, expObject, "not equal (" + actObject.getClass().getSimpleName() + ")");
             }
         }

--- a/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
@@ -1715,4 +1715,10 @@ public class ScriptTest {
         assertTrue(Script.matchNamed(MatchType.EQUALS, "bar", null, "{ bar: 10 }", ctx).pass);
     }
 
+    @Test
+    public void notEqualMatchTest(){
+        Map<String, Object> result = Runner.runFeature(getClass(), "core/notEqualMatch.feature", null, true);
+        assertNotEquals(result.get("a"),result.get("b"));
+    }
+
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/notEqualMatch.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/notEqualMatch.feature
@@ -1,0 +1,10 @@
+Feature: not equal match test file
+
+# some comment
+
+  Background:
+    Given def a = 456
+    Given def b = 120
+
+  Scenario: test
+    Then match a != b


### PR DESCRIPTION
### Description

Hacktoberfest
Adding fix and test case for https://github.com/intuit/karate/issues/917

- Relevant Issues : match with not equals not working label:hacktoberfest
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
