### PR TITLE
update supervisord command to be the correct path for google-chrome

### DIFF
--- a/karate-docker/karate-chrome/supervisord.conf
+++ b/karate-docker/karate-chrome/supervisord.conf
@@ -17,7 +17,7 @@ priority=100
 
 [program:chrome]
 environment=HOME="/home/chrome",DISPLAY=":1",USER="chrome",DBUS_SESSION_BUS_ADDRESS="unix:path=/dev/null"
-command=/opt/google/chrome/chrome 
+command=/usr/bin/google-chrome
     --user-data-dir=/home/chrome
     --no-first-run
     --disable-translate


### PR DESCRIPTION
### Description

This PR changes the command path to be the correct one for new builds of the google-chrome browser in Linux. I've built and tested this as noted in https://github.com/intuit/karate/wiki/Docker and confirms it launches google-chrome as desired.

- Relevant Issues : https://github.com/intuit/karate/issues/923
- Relevant PRs : N/A
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
