### PR TITLE
Updating version gatling-maven-plugin to 3.0.2

### DIFF
--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>io.gatling</groupId>
                 <artifactId>gatling-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <disableCompiler>true</disableCompiler>
                     <skip>${skipTests}</skip>


### PR DESCRIPTION
### Description

Updating version gatling-maven-plugin to fix NoClassDefFound error

- Relevant Issues : #936
- Relevant PRs : #940
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
