### PR TITLE
example of multistage docker build to add chrome version as a label

### DIFF
--- a/karate-docker/karate-chrome/Dockerfile
+++ b/karate-docker/karate-chrome/Dockerfile
@@ -1,31 +1,11 @@
-FROM maven:3-jdk-8
+FROM karate-chrome:build
 
 LABEL maintainer="Peter Thomas"
 LABEL url="https://github.com/intuit/karate/tree/master/karate-docker/karate-chrome"
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-	xvfb \
-	x11vnc \
-	supervisor \
-	gdebi \
-	gnupg2 \
-	fonts-takao \
-	pulseaudio \
-	socat \
-	ffmpeg
+ARG chrome_version='N/A'
 
-ADD https://dl.google.com/linux/linux_signing_key.pub \
-	https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-	/tmp/
-
-RUN apt-key add /tmp/linux_signing_key.pub \
-	&& gdebi --non-interactive /tmp/google-chrome-stable_current_amd64.deb
-
-RUN apt-get clean \
-	&& rm -rf /var/cache/* /var/log/apt/* /var/lib/apt/lists/* /tmp/* \
-	&& useradd -m -G pulse-access chrome \
-	&& usermod -s /bin/bash chrome
+LABEL chrome.version=${chrome_version}
 
 RUN mkdir ~/.vnc && \
     x11vnc -storepasswd karate ~/.vnc/passwd

--- a/karate-docker/karate-chrome/Dockerfile.build
+++ b/karate-docker/karate-chrome/Dockerfile.build
@@ -1,0 +1,30 @@
+FROM maven:3-jdk-8
+
+LABEL maintainer="Peter Thomas"
+LABEL url="https://github.com/intuit/karate/tree/master/karate-docker/karate-chrome"
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	xvfb \
+	x11vnc \
+	supervisor \
+	gdebi \
+	gnupg2 \
+	fonts-takao \
+	pulseaudio \
+	socat \
+	ffmpeg
+
+ADD https://dl.google.com/linux/linux_signing_key.pub \
+	https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+	/tmp/
+
+RUN apt-key add /tmp/linux_signing_key.pub \
+	&& gdebi --non-interactive /tmp/google-chrome-stable_current_amd64.deb
+
+RUN apt-get clean \
+	&& rm -rf /var/cache/* /var/log/apt/* /var/lib/apt/lists/* /tmp/* \
+	&& useradd -m -G pulse-access chrome \
+	&& usermod -s /bin/bash chrome
+
+CMD ["/bin/bash" ]

--- a/karate-docker/karate-chrome/build.sh
+++ b/karate-docker/karate-chrome/build.sh
@@ -3,4 +3,8 @@ set -x -e
 cd ../..
 docker run -it --rm -v "$(pwd)":/karate -w /karate -v "$(pwd)"/karate-docker/karate-chrome/target:/root/.m2 maven:3-jdk-8 bash karate-docker/karate-chrome/install.sh
 cd karate-docker/karate-chrome
-docker build -t karate-chrome .
+docker build -t karate-chrome:build . -f Dockerfile.build
+
+CHROME_VERSION=`docker run --rm -it karate-chrome:build /usr/bin/google-chrome --version | cut -d' ' -f3`
+
+docker build --build-arg chrome_version=${CHROME_VERSION} -t karate-chrome:latest . -f Dockerfile


### PR DESCRIPTION
Here is an example of what could work as far as labelling the built karate-chrome container with what the contained version of Chrome is. There isn't really a way to 'know' which version you're installing (That I've found) and its impossible to set a label as a variable inside a single dockerfile, hence the multi-stage addition. 

No need to merge this, but I figured it did a fairly good job of explaining part of my thought process in https://github.com/intuit/karate/issues/939 

Here is what the inspect looks like:
```
docker inspect -f {{.Config.Labels}} karate-chrome:latest
map[chrome.version:78.0.3904.70 maintainer:Peter Thomas url:https://github.com/intuit/karate/tree/master/karate-docker/karate-chrome]
```
or even:
```
docker inspect -f '{{index .Config.Labels "chrome.version"}}' karate-chrome:latest
78.0.3904.70
```

- Relevant Issues : https://github.com/intuit/karate/issues/939
- Relevant PRs : N/A
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
