### PR TITLE
Fix formatting in pages site

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -352,7 +352,7 @@ To try this or especially when you need to investigate why a test is not behavin
   * this would include the `stderr` and `stdout` logs from Chrome, which can be helpful for troubleshooting
 
 ## Driver Types
-type | default<br/>port | default<br/>executable | description
+type | default port | default executable | description
 ---- | ---------------- | ---------------------- | -----------
 [`chrome`](https://chromedevtools.github.io/devtools-protocol/) | 9222 | mac: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`<br/>win: `C:/Program Files (x86)/Google/Chrome/Application/chrome.exe` | "native" Chrome automation via the [DevTools protocol](https://chromedevtools.github.io/devtools-protocol/)
 [`chromedriver`](https://sites.google.com/a/chromium.org/chromedriver/home) | 9515 | `chromedriver` | W3C Chrome Driver


### PR DESCRIPTION
### Description

- Relevant Issues: The markdown table formatting on the Github pages site seems to be breaking because of the `<br/>` tags.
<img width="791" alt="Screen Shot 2019-11-01 at 11 08 06 AM" src="https://user-images.githubusercontent.com/10023615/68004581-10e23700-fc98-11e9-9413-8e63b7a6e1cb.png">

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation
