### PR TITLE
added required dependencies to compile karate on java 11+

### DIFF
--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -103,7 +103,22 @@
             <artifactId>geronimo-jms_1.1_spec</artifactId>
             <version>1.1.1</version>
             <scope>test</scope>
-        </dependency>                                                           		
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/karate-ui/pom.xml
+++ b/karate-ui/pom.xml
@@ -11,6 +11,13 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-swing -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>12-ea+9</version>
+        </dependency>
+
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>


### PR DESCRIPTION
Tried compiling the project on openjdk 1.8.0_232, but could not get it to work. After adding the following dependencies was able to compile karate on java 11+