### PR TITLE
support headless flag for firefox

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -266,10 +266,15 @@ public class DriverOptions {
     }
     
     private Map<String, Object> getCapabilities(String browserName) {
-        Map<String, Object> map = new LinkedHashMap();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("browserName", browserName);
         if (proxy != null) {
             map.put("proxy", proxy);
+        }
+        if (headless && browserName.equals("firefox")) {
+            map.put("moz:firefoxOptions",
+                    Collections.singletonMap("args", Collections.singletonList("-headless")));
+            map = Collections.singletonMap("alwaysMatch", map);
         }
         return Collections.singletonMap("capabilities", map);
     }
@@ -277,13 +282,13 @@ public class DriverOptions {
     public Map<String, Object> getCapabilities() {
         switch (type) {
             case "chromedriver":
-                return getCapabilities("Chrome");
+                return getCapabilities("chrome");
             case "geckodriver":
-                return getCapabilities("Firefox");
+                return getCapabilities("firefox");
             case "safaridriver":
-                return getCapabilities("Safari");
+                return getCapabilities("safari");
             case "mswebdriver":
-                return getCapabilities("Edge");
+                return getCapabilities("edge");
             default:
                 return null;
         }


### PR DESCRIPTION
### Description

Support for headless flag in configure driver { type: 'geckodriver', headless: true }.
This will add the -headless flag to 'moz:firefoxOptions' in the capabilities when starting a New Session.

- Relevant Issues : #1015 
- Type of change :
  - [X] New feature