### PR TITLE
Fix for multiple threads getting assigned the same port

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/firefox/GeckoWebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/firefox/GeckoWebDriver.java
@@ -81,6 +81,13 @@ public class GeckoWebDriver extends WebDriver {
                 logger.warn("native window switch failed: {}", e.getMessage());
             }
         }
-    }        
+    }
+
+    @Override
+    public void quit() {
+        // geckodriver already closes all windows on delete session
+        open = false;
+        super.quit();
+    }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/shell/Command.java
+++ b/karate-core/src/main/java/com/intuit/karate/shell/Command.java
@@ -86,7 +86,7 @@ public class Command extends Thread {
 
     private static final Set<Integer> PORTS_IN_USE = ConcurrentHashMap.newKeySet();
 
-    public static int getFreePort(int preferred) {
+    public static synchronized int getFreePort(int preferred) {
         if (preferred != 0 && PORTS_IN_USE.contains(preferred)) {
             LOGGER.trace("preferred port {} in use (karate), will attempt to find free port ...", preferred);
             preferred = 0;


### PR DESCRIPTION
### Description

Due to a race condition in reading/writing PORTS_IN_USE, function getFreePort can return the same port number multiple times for different threads.
This is fixed by making it 'synchronized'.

As a bonus geckodriver no longer closes the window before quiting. Close window will close the session when there is only one window. Therefore the subsequent quit command will fail with "invalid session id".

- Relevant Issues : #1022
- Relevant PRs : (optional)
- Type of change :
  - [X] Bug fix for existing feature
