### PR TITLE
Add support for 'acceptInsecureCerts' W3C browser capability

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -248,6 +248,7 @@ key | description
 `pollAttempts` | optional, will default to `20`, you normally never need to change this (and changing `pollInterval` is preferred), and this is the number of attempts Karate will make to wait for the `port` to be ready and accepting connections before proceeding
 `pollInterval` | optional, will default to `250` (milliseconds) and you normally never need to change this (see `pollAttempts`) unless the driver `executable` takes a *very* long time to start
 `headless` | [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome) only applies to `{ type: 'chrome' }` and `{ type: 'geckodriver' }` for now, also see [`DockerTarget`](#dockertarget)
+`acceptInsecureCerts` | default `false`, when `true` disables SSL certificate checks in browser
 `showDriverLog` | default `false`, will include webdriver HTTP traffic in Karate report, useful for troubleshooting or bug reports
 `showProcessLog` | default `false`, will include even executable (webdriver or browser) logs in the Karate report
 `addOptions` | default `null`, has to be a list / JSON array that will be appended as additional CLI arguments to the `executable`, e.g. `['--no-sandbox', '--windows-size=1920,1080']`

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -78,6 +78,7 @@ public class DriverOptions {
     public final int pollAttempts;
     public final int pollInterval;
     public final boolean headless;
+    public final boolean acceptInsecureCerts;
     public final boolean showProcessLog;
     public final boolean showDriverLog;
     public final Logger logger;
@@ -90,7 +91,7 @@ public class DriverOptions {
     public final String processLogFile;
     public final int maxPayloadSize;
     public final List<String> addOptions;
-    public final List<String> args = new ArrayList();
+    public final List<String> args = new ArrayList<>();
     public final Map<String, Object> proxy;
     public final Target target;
     public final String beforeStart;
@@ -150,6 +151,7 @@ public class DriverOptions {
         start = get("start", true);
         executable = get("executable", defaultExecutable);
         headless = get("headless", false);
+        acceptInsecureCerts = get("acceptInsecureCerts", false);
         showProcessLog = get("showProcessLog", false);
         addOptions = get("addOptions", null);
         uniqueName = type + "_" + System.currentTimeMillis();
@@ -274,6 +276,9 @@ public class DriverOptions {
         if (headless && browserName.equals("firefox")) {
             map.put("moz:firefoxOptions",
                     Collections.singletonMap("args", Collections.singletonList("-headless")));
+        }
+        if (acceptInsecureCerts) {
+            map.put("acceptInsecureCerts", true);
         }
         map = Collections.singletonMap("alwaysMatch", map);
         return Collections.singletonMap("capabilities", map);


### PR DESCRIPTION
Add support for 'acceptInsecureCerts' W3C browser capability to disable SSL checks and allow self-signed certificates.

- Relevant Issues : #924
- Type of change :
  - [X] New feature
