### PR TITLE
Add example of test data to archetype.

### DIFF
--- a/karate-archetype/src/main/resources/archetype-resources/src/test/java/data.json
+++ b/karate-archetype/src/main/resources/archetype-resources/src/test/java/data.json
@@ -1,0 +1,8 @@
+{
+  "dev": {
+    "test1": { "data1": "val1", "data2": "val2"}
+  },
+  "e2e": {
+    "test1": { "data1": "val1", "data2": "val2"}
+  }
+}

--- a/karate-archetype/src/main/resources/archetype-resources/src/test/java/karate-config.js
+++ b/karate-archetype/src/main/resources/archetype-resources/src/test/java/karate-config.js
@@ -6,13 +6,18 @@ function fn() {
   }
   var config = {
     env: env,
-	myVarName: 'someValue'
+	myVarName: 'someValue',
+	data: read("classpath:data.json")[this_env]
   }
   if (env == 'dev') {
     // customize
     // e.g. config.foo = 'bar';
   } else if (env == 'e2e') {
     // customize
+  }
+
+  for (p in config) {
+    karate.log ("##### config - " + p, ": " + config[p])
   }
   return config;
 }


### PR DESCRIPTION
### Description

I was looking at the Maven archetype.  I might like to contribute some improvements to the archetype, and I am just testing the water with this change to the `karate-config.js` .   

Next up after this PR:  I might like to add a HTML report configuration to the archetype  and/or archetype option for JUnit5 vs. TestNG.

I know this archetype is important for others to reproduce feature requests and bugs.   So, my improvements will have that in mind.

- Relevant Issues : none
- Relevant PRs : none
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [X ] Addition or Improvement of documentation
