### PR TITLE
Make tests more stable by using JSONAssert equals and XMLUnit

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -112,7 +112,7 @@ key | description
 `showProcessLog` | default `false`, will include even executable (webdriver or browser) logs in the Karate report
 
 ## Driver Types
-type | default<br/>port | default<br/>executable | description
+type | default port | default executable | description
 ---- | ---------------- | ---------------------- | -----------
 [`chrome`](https://chromedevtools.github.io/devtools-protocol/) | 9222 | mac: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`<br/>win: `C:/Program Files (x86)/Google/Chrome/Application/chrome.exe` | "native" Chrome automation via the [DevTools protocol](https://chromedevtools.github.io/devtools-protocol/)
 [`chromedriver`](https://sites.google.com/a/chromium.org/chromedriver/home) | 9515 | `chromedriver` | W3C Chrome Driver

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -76,7 +76,18 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>		
-    </dependencies>
+       <dependency>
+        <groupId>org.xmlunit</groupId>
+        <artifactId>xmlunit-matchers</artifactId>
+        <version>2.2.1</version>
+            <scope>test</scope>
+       </dependency>
+       <dependency>
+           <groupId>org.skyscreamer</groupId>
+           <artifactId>jsonassert</artifactId>
+           <version>1.5.0</version>
+       </dependency>
+  </dependencies>
 
     <build>
         <resources>
@@ -118,8 +129,8 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>                   
-        </plugins>               
+            </plugin>
+        </plugins>
     </build>
     
     <profiles>

--- a/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
@@ -10,7 +10,12 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.json.JSONException;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 /**
  *
  * @author pthomas3
@@ -142,9 +147,11 @@ public class JsonUtilsTest {
                 + "}\n";
         assertEquals(temp, expected);
     }
-    
+    public void assertJSONequals(String s1, String s2) throws JSONException{
+        JSONAssert.assertEquals(s1, s2, false);
+    } 
     @Test
-    public void testPojoConversion() {
+    public void testPojoConversion() throws JSONException{
         ComplexPojo pojo = new ComplexPojo();
         pojo.setFoo("testFoo");
         pojo.setBar(1);
@@ -155,7 +162,7 @@ public class JsonUtilsTest {
         pojo.setBan(Arrays.asList(p1, p2));
         String s = JsonUtils.toJson(pojo);
         String expected = "{\"bar\":1,\"foo\":\"testFoo\",\"baz\":null,\"ban\":[{\"bar\":0,\"foo\":\"p1\",\"baz\":null,\"ban\":null},{\"bar\":0,\"foo\":\"p2\",\"baz\":null,\"ban\":null}]}";
-        assertEquals(s, expected);
+        assertJSONequals(s, expected);
         ComplexPojo temp = (ComplexPojo) JsonUtils.fromJson(s, ComplexPojo.class.getName());
         assertEquals(temp.getFoo(), "testFoo");
         assertEquals(2, temp.getBan().size());
@@ -163,8 +170,10 @@ public class JsonUtilsTest {
         assertEquals(temp.getFoo(), "testFoo");
         assertEquals(2, temp.getBan().size());        
         s = XmlUtils.toXml(pojo);
-        assertEquals(s, "<root><bar>1</bar><foo>testFoo</foo><baz/><ban><bar>0</bar><foo>p1</foo><baz/><ban/></ban><ban><bar>0</bar><foo>p2</foo><baz/><ban/></ban></root>");
-    }
+        String expectedXML="<root><bar>1</bar><foo>testFoo</foo><baz/><ban><bar>0</bar><foo>p1</foo><baz/><ban/></ban><ban><bar>0</bar><foo>p2</foo><baz/><ban/></ban></root>";
+	assertThat(s, isSimilarTo(expectedXML).ignoreWhitespace()
+             .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
+      }
     
     @Test
     public void testEmptyJsonObject() {


### PR DESCRIPTION
### Description

Tests in `testPojoConversion`  in `com.intuit.karate.JsonUtilsTest#testPojoConversion` compare stringify results to hard-coded strings. The `toJson` method actually depends on `toJSONString`. However, the `toJSONString` method is similar with `Object’s toString()`. The order of this API is not guaranteed so the `json` results can contain entries in any order. Thus, tests may fail or pass without any changes made to the source code and cannot serve as good regression tests.


This PR proposes to use JSONAssert and modify the corresponding json test assertions so that the test is more stable, and it also proposes to use XMLUnit to fix similar problem. It ignores the order of XML elements to make the tests more robust.


- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
