### PR TITLE
Remove namespace when matching xml

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1010,8 +1010,8 @@ public class Script {
         switch (expected.getType()) {
             case XML: // convert to map and then compare               
                 Node expNode = expected.getValue(Node.class);
-                expObject = XmlUtils.toObject(expNode);
-                actObject = XmlUtils.toObject(actual.getValue(Node.class));
+                expObject = XmlUtils.toObjectWithoutNamespace(expNode);
+                actObject = XmlUtils.toObjectWithoutNamespace(actual.getValue(Node.class));
                 break;
             case MAP: // expected is already in map form, convert the actual also
                 expObject = expected.getValue(Map.class);

--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1010,8 +1010,8 @@ public class Script {
         switch (expected.getType()) {
             case XML: // convert to map and then compare               
                 Node expNode = expected.getValue(Node.class);
-                expObject = XmlUtils.toObjectWithoutNamespace(expNode);
-                actObject = XmlUtils.toObjectWithoutNamespace(actual.getValue(Node.class));
+                expObject = XmlUtils.toObject(expNode, true);
+                actObject = XmlUtils.toObject(actual.getValue(Node.class), true);
                 break;
             case MAP: // expected is already in map form, convert the actual also
                 expObject = expected.getValue(Map.class);

--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -335,39 +335,6 @@ public class XmlUtils {
         }
         return map;
     }
-    private static Object getElementAsObjectWithoutNamespace(Node node) {
-        int childElementCount = getChildElementCount(node);
-        if (childElementCount == 0) {
-            return StringUtils.trimToNull(node.getTextContent());
-        }
-        Map<String, Object> map = new LinkedHashMap<>(childElementCount);
-        NodeList nodes = node.getChildNodes();
-        int childCount = nodes.getLength();
-        for (int i = 0; i < childCount; i++) {
-            Node child = nodes.item(i);
-            if (child.getNodeType() != Node.ELEMENT_NODE) {
-                continue;
-            }
-            String childName = child.getNodeName().replaceFirst("(^.*:)", "");
-            Object childValue = toObjectWithoutNamespace(child);
-            // auto detect repeating elements
-            if (map.containsKey(childName)) {
-                Object temp = map.get(childName);
-                if (temp instanceof List) {
-                    List list = (List) temp;
-                    list.add(childValue);
-                } else {
-                    List list = new ArrayList(childCount);
-                    map.put(childName, list);
-                    list.add(temp);
-                    list.add(childValue);
-                }
-            } else {
-                map.put(childName, childValue);
-            }
-        }
-        return map;
-    }
 
     public static Object toObject(Node node) {
         return toObject(node, false);
@@ -388,34 +355,6 @@ public class XmlUtils {
             if(removeNamespace) {
                 attribs.keySet().removeIf(key -> "xmlns".equals(key) || key.startsWith("xmlns:"));
             }
-            if(attribs.size() > 0) {
-                Map<String, Object> wrapper = new LinkedHashMap<>(2);
-                wrapper.put("_", value);
-                wrapper.put("@", attribs);
-                return wrapper;
-            }else {
-                //namespaces were the only attributes
-                return value;
-            }
-        } else {
-            return value;
-        }
-    }
-
-    //Strip prefix and any "xmlns" attributes for matching purposes
-    public static Object toObjectWithoutNamespace(Node node) {
-
-        if (node.getNodeType() == Node.DOCUMENT_NODE) {
-            node = node.getFirstChild();
-            String name = node.getNodeName().replaceFirst("(^.*:)", "");
-            Map<String, Object> map = new LinkedHashMap<>(1);
-            map.put(name, toObjectWithoutNamespace(node));
-            return map;
-        }
-        Object value = getElementAsObjectWithoutNamespace(node);
-        if (node.hasAttributes()) {
-            Map<String, Object> attribs = getAttributes(node);
-            attribs.keySet().removeIf(key -> "xmlns".equals(key) || key.startsWith("xmlns:"));
             if(attribs.size() > 0) {
                 Map<String, Object> wrapper = new LinkedHashMap<>(2);
                 wrapper.put("_", value);

--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -25,6 +25,7 @@ package com.intuit.karate;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -47,6 +48,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -58,7 +60,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- *
  * @author pthomas3
  */
 public class XmlUtils {
@@ -352,15 +353,15 @@ public class XmlUtils {
         Object value = getElementAsObject(node, removeNamespace);
         if (node.hasAttributes()) {
             Map<String, Object> attribs = getAttributes(node);
-            if(removeNamespace) {
+            if (removeNamespace) {
                 attribs.keySet().removeIf(key -> "xmlns".equals(key) || key.startsWith("xmlns:"));
             }
-            if(attribs.size() > 0) {
+            if (attribs.size() > 0) {
                 Map<String, Object> wrapper = new LinkedHashMap<>(2);
                 wrapper.put("_", value);
                 wrapper.put("@", attribs);
                 return wrapper;
-            }else {
+            } else {
                 //namespaces were the only attributes
                 return value;
             }

--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -334,6 +334,39 @@ public class XmlUtils {
         }
         return map;
     }
+    private static Object getElementAsObjectWithoutNamespace(Node node) {
+        int childElementCount = getChildElementCount(node);
+        if (childElementCount == 0) {
+            return StringUtils.trimToNull(node.getTextContent());
+        }
+        Map<String, Object> map = new LinkedHashMap<>(childElementCount);
+        NodeList nodes = node.getChildNodes();
+        int childCount = nodes.getLength();
+        for (int i = 0; i < childCount; i++) {
+            Node child = nodes.item(i);
+            if (child.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            String childName = child.getNodeName().replaceFirst("(^.*:)", "");
+            Object childValue = toObjectWithoutNamespace(child);
+            // auto detect repeating elements
+            if (map.containsKey(childName)) {
+                Object temp = map.get(childName);
+                if (temp instanceof List) {
+                    List list = (List) temp;
+                    list.add(childValue);
+                } else {
+                    List list = new ArrayList(childCount);
+                    map.put(childName, list);
+                    list.add(temp);
+                    list.add(childValue);
+                }
+            } else {
+                map.put(childName, childValue);
+            }
+        }
+        return map;
+    }
 
     public static Object toObject(Node node) {
         if (node.getNodeType() == Node.DOCUMENT_NODE) {
@@ -348,6 +381,34 @@ public class XmlUtils {
             wrapper.put("_", value);
             wrapper.put("@", getAttributes(node));
             return wrapper;
+        } else {
+            return value;
+        }
+    }
+
+    //Strip prefix and any "xmlns" attributes for matching purposes
+    public static Object toObjectWithoutNamespace(Node node) {
+
+        if (node.getNodeType() == Node.DOCUMENT_NODE) {
+            node = node.getFirstChild();
+            String name = node.getNodeName().replaceFirst("(^.*:)", "");
+            Map<String, Object> map = new LinkedHashMap<>(1);
+            map.put(name, toObjectWithoutNamespace(node));
+            return map;
+        }
+        Object value = getElementAsObjectWithoutNamespace(node);
+        if (node.hasAttributes()) {
+            Map<String, Object> attribs = getAttributes(node);
+            attribs.keySet().removeIf(key -> "xmlns".equals(key) || key.startsWith("xmlns:"));
+            if(attribs.size() > 0) {
+                Map<String, Object> wrapper = new LinkedHashMap<>(2);
+                wrapper.put("_", value);
+                wrapper.put("@", attribs);
+                return wrapper;
+            }else {
+                //namespaces were the only attributes
+                return value;
+            }
         } else {
             return value;
         }

--- a/karate-core/src/test/java/com/intuit/karate/MatchTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/MatchTest.java
@@ -53,6 +53,14 @@ public class MatchTest {
     }
 
     @Test
+    public void testXmlNamespaced() {
+        new Match("<foo:cat xmlns:foo=\"foobar\">a</foo:cat>").equals("<bar:cat xmlns:bar=\"foobar\">a</bar:cat>");
+        new Match("<foo:cat xmlns:foo=\"foobar\" xmlns:bar=\"https:github.com\"><bar:dog>a</bar:dog></foo:cat>")
+                .equals("<foo2:cat xmlns:foo2=\"foobar\" xmlns:bar2=\"https:github.com\"><bar2:dog>a</bar2:dog></foo2:cat>");
+
+    }
+
+    @Test
     public void testString() {
         Match.equalsText("foo", "foo");
         Match.containsText("foo", "foo");

--- a/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
@@ -49,6 +49,16 @@ public class XmlUtilsTest {
     }
 
     @Test
+    public void testConvertingToMapWithoutNamespace() {
+        String xml = "<foo xmlns=\"foobar\"><a:bar xmlns:a=\"test\">baz</a:bar></foo>";
+        Document doc = XmlUtils.toXmlDoc(xml);
+        Map<String, Object> map = (Map) XmlUtils.toObjectWithoutNamespace(doc);
+        logger.trace("map: {}", map);
+        Map inner = (Map) map.get("foo");
+        assertEquals("baz", inner.get("bar"));
+    }
+
+    @Test
     public void testComplexConversionToMap() {
         Document doc = XmlUtils.toXmlDoc(ACTUAL);
         Map<String, Object> map = (Map) XmlUtils.toObject(doc);

--- a/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/XmlUtilsTest.java
@@ -52,7 +52,7 @@ public class XmlUtilsTest {
     public void testConvertingToMapWithoutNamespace() {
         String xml = "<foo xmlns=\"foobar\"><a:bar xmlns:a=\"test\">baz</a:bar></foo>";
         Document doc = XmlUtils.toXmlDoc(xml);
-        Map<String, Object> map = (Map) XmlUtils.toObjectWithoutNamespace(doc);
+        Map<String, Object> map = (Map) XmlUtils.toObject(doc, true);
         logger.trace("map: {}", map);
         Map inner = (Map) map.get("foo");
         assertEquals("baz", inner.get("bar"));

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/xml/xml.feature
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/xml/xml.feature
@@ -442,3 +442,17 @@ Scenario: repeated xml elements and fuzzy matching
     * match response == { response: { foo: { bar: '#[] bar.bar' } } }
     # so yes, we can express expected data in xml
     * match response == <response><foo><bar>#[] bar.bar</bar></foo></response>
+
+Scenario: matching ignores xml prefixes
+    * def search = { number: '123456', wireless: true, voip: false, tollFree: false }
+    * def xml = read('soap1.xml')
+
+    * def phoneNumberSearchOption =
+    """
+    <foo:phoneNumberSearchOption xmlns:foo="http://foo/bar">
+        <foo:searchWirelessInd>#(search.wireless)</foo:searchWirelessInd>
+        <foo:searchVoipInd>#(search.voip)</foo:searchVoipInd>
+        <foo:searchTollFreeInd>#(search.tollFree)</foo:searchTollFreeInd>
+    </foo:phoneNumberSearchOption>
+    """
+    * match xml /Envelope/Body/getAccountByPhoneNumber/phoneNumberSearchOption == phoneNumberSearchOption


### PR DESCRIPTION
When matching xml, the prefix is currently treated  as part of the name of the element. This can cause otherwise identical elements to not match in cases such as when the prefix is generated and can't be known beforehand.
Removing the prefix and namespacing attributes from the map representation will let these elements match.

- Relevant Issues : #1051
- Type of change :
  - [x] Bug fix for existing feature

