### PR TITLE
Allow MultiPartItem without filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1848,7 +1848,7 @@ Note that `multipart file` takes a JSON argument so that you can easily set the 
 
 * `read`: the name of a file, and the [`classpath:`](#reading-files) prefix also is allowed. mandatory unless `value` is used, see below.
 * `value`: alternative to `read` in rare cases where something like a JSON or XML file is being uploaded and you want to create it dynamically.
-* `filename`: optional, will default to the multipart field name if not specified
+* `filename`: optional, if not specified there will be no `filename` attribute in `Content-Disposition` 
 * `contentType`: optional, will default to `application/octet-stream`
 
 When 'multipart' content is involved, the `Content-Type` header of the HTTP request defaults to `multipart/form-data`.

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioContext.java
@@ -786,9 +786,6 @@ public class ScenarioContext {
         }
         MultiPartItem item = new MultiPartItem(name, fileValue);
         String filename = asString(map, "filename");
-        if (filename == null) {
-            filename = name;
-        }
         item.setFilename(filename);
         String contentType = asString(map, "contentType");
         if (contentType != null) {


### PR DESCRIPTION
### Description

As discussed here [on Stackoverflow](https://stackoverflow.com/q/60649779/6438521), we would send multipart files without a filename. This PR adds an additional property `omitFilename` in order to send requests without a filename in `Content-Disposition`.

- Type of change :
  - [X] New feature