### PR TITLE
Adding changes to support contains in array recursively.

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1145,6 +1145,7 @@ public class Script {
             case NOT_CONTAINS:
             case CONTAINS_ONLY:
             case CONTAINS_ANY:
+            case CONTAINS_DEEP:
                 if (actObject instanceof List && !(expObject instanceof List)) { // if RHS is not a list, make it so
                     expObject = Collections.singletonList(expObject);
                 }
@@ -1378,7 +1379,7 @@ public class Script {
                     return matchFailed(matchType, path, actObject, expObject, "all key-values did not match, expected has un-matched keys: " + unMatchedKeysExp);
                 }
             } else if (!unMatchedKeysAct.isEmpty()) {
-                if (matchType == MatchType.CONTAINS || expMap.isEmpty()) {
+                if (matchType == MatchType.CONTAINS || matchType == MatchType.CONTAINS_DEEP || expMap.isEmpty()) {
                     return AssertionResult.PASS;
                 }
                 if (matchType == MatchType.NOT_EQUALS) {
@@ -1420,13 +1421,16 @@ public class Script {
             if (matchType == MatchType.CONTAINS
                     || matchType == MatchType.CONTAINS_ONLY
                     || matchType == MatchType.CONTAINS_ANY
-                    || matchType == MatchType.NOT_CONTAINS) { // just checks for existence (or non-existence)
+                    || matchType == MatchType.NOT_CONTAINS
+                    || matchType == MatchType.CONTAINS_DEEP
+            ) { // just checks for existence (or non-existence)
                 for (Object expListObject : expList) { // for each expected item in the list
                     boolean found = false;
                     for (int i = 0; i < actCount; i++) {
                         Object actListObject = actList.get(i);
                         String listPath = buildListPath(delimiter, path, i);
-                        AssertionResult ar = matchNestedObject(delimiter, listPath, MatchType.EQUALS, actRoot, actListObject, actListObject, expListObject, context);
+                        MatchType childMatchType = matchType.equals(MatchType.CONTAINS_DEEP)? MatchType.CONTAINS_DEEP : MatchType.EQUALS;
+                        AssertionResult ar = matchNestedObject(delimiter, listPath, childMatchType, actRoot, actListObject, actListObject, expListObject, context);
                         if (ar.pass) { // exact match, we found it
                             found = true;
                             break;

--- a/karate-core/src/main/java/com/intuit/karate/Script.java
+++ b/karate-core/src/main/java/com/intuit/karate/Script.java
@@ -1334,7 +1334,12 @@ public class Script {
                 }
                 Object childAct = actMap.get(key);
                 ScriptValue childActValue = new ScriptValue(childAct);
-                MatchType childMatchType = childActValue.isJsonLike() ? matchType : MatchType.EQUALS;
+                MatchType childMatchType = MatchType.EQUALS;
+                if (matchType.equals(MatchType.CONTAINS_DEEP)) {
+                    if (childActValue.isJsonLike()) {
+                        childMatchType = MatchType.CONTAINS_DEEP;
+                    }
+                }
                 AssertionResult ar = matchNestedObject(delimiter, childPath, childMatchType, actRoot, actMap, childAct, childExp, context);
                 if (ar.pass) { // values for this key match                    
                     if (matchType == MatchType.CONTAINS_ANY) {

--- a/karate-core/src/main/java/com/intuit/karate/core/MatchStep.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/MatchStep.java
@@ -49,6 +49,7 @@ public class MatchStep {
         boolean not = false;
         boolean only = false;
         boolean any = false;
+        boolean deep = false;
         int spacePos = raw.indexOf(' ');
         int leftParenPos = raw.indexOf('(');
         int rightParenPos = raw.indexOf(')');
@@ -65,15 +66,19 @@ public class MatchStep {
             contains = true;
             not = raw.charAt(lhsEndPos + 1) == '!';
             searchPos = lhsEndPos + (not ? 10 : 9);
-            String anyOrOnly = raw.substring(searchPos).trim();
-            if (anyOrOnly.startsWith("only")) {
+            String anyOrOnlyOrDeep = raw.substring(searchPos).trim();
+            if (anyOrOnlyOrDeep.startsWith("only")) {
                 int onlyPos = raw.indexOf(" only", searchPos);
                 only = true;
                 searchPos = onlyPos + 5;
-            } else if (anyOrOnly.startsWith("any")) {
+            } else if (anyOrOnlyOrDeep.startsWith("any")) {
                 int anyPos = raw.indexOf(" any", searchPos);
                 any = true;
                 searchPos = anyPos + 4;
+            } else if (anyOrOnlyOrDeep.startsWith("deep")) {
+                int deepPos = raw.indexOf(" deep", searchPos);
+                deep = true;
+                searchPos = deepPos + 5;
             }
         } else {
             int equalPos = raw.indexOf(" ==", searchPos);
@@ -106,7 +111,7 @@ public class MatchStep {
             path = null;
         }
         expected = StringUtils.trimToNull(raw.substring(searchPos));
-        type = getType(each, not, contains, only, any);
+        type = getType(each, not, contains, only, any, deep);
     }
 
     private static int min(int a, int b) {
@@ -119,7 +124,7 @@ public class MatchStep {
         return Math.min(a, b);
     }
 
-    private static MatchType getType(boolean each, boolean not, boolean contains, boolean only, boolean any) {
+    private static MatchType getType(boolean each, boolean not, boolean contains, boolean only, boolean any, boolean deep) {
         if (each) {
             if (contains) {
                 if (only) {
@@ -138,6 +143,9 @@ public class MatchStep {
             }
             if (any) {
                 return MatchType.CONTAINS_ANY;
+            }
+            if (deep) {
+                return MatchType.CONTAINS_DEEP;
             }
             return not ? MatchType.NOT_CONTAINS : MatchType.CONTAINS;
         }

--- a/karate-core/src/main/java/com/intuit/karate/core/MatchType.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/MatchType.java
@@ -12,6 +12,7 @@ public enum MatchType {
     NOT_CONTAINS,
     CONTAINS_ONLY,
     CONTAINS_ANY,
+    CONTAINS_DEEP,
     EACH_EQUALS,
     EACH_NOT_EQUALS,
     EACH_CONTAINS,

--- a/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
@@ -390,27 +390,39 @@ public class ScriptTest {
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 1, baz: 'a'}, {bar: 2, baz: 'b'}, {bar:3, baz: 'c'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ANY, myJson, "$.foo", "[{bar: 9, baz: 'z'}, {bar: 2, baz: 'b'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar:3, baz: 'c'}]", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{bar: 1}, {bar: 2}, {bar:3}]}", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]}", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar:3, baz: 'c'}]}", ctx).pass);
 
         // shuffle
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar:3, baz: 'c'}]}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 2, baz: 'b'}, {bar:3, baz: 'c'}, {bar: 1, baz: 'a'}]", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar:3, baz: 'c'}]", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 1, baz: 'a'}, {bar: 2, baz: 'b'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_EQUALS, myJson, "$.foo", "{bar:'#number', baz:'#string'}", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_CONTAINS, myJson, "$.foo", "{bar:'#number'}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_CONTAINS, myJson, "$.foo", "{baz:'#string'}", ctx).pass);
-        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_NOT_CONTAINS, myJson, "$.foo", "{baz:'z'}", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.EACH_NOT_CONTAINS, myJson, "$.foo", "{baz:'a'}", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.EACH_EQUALS, myJson, "$.foo", "{bar:'#? _ < 3',  baz:'#string'}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{bar: 1}, {bar: 2}, {bar:3}]}", ctx).pass);
+
+    }
+
+    @Test
+    public void testMatchContainsDeep() {
+
+        DocumentContext doc = JsonPath.parse("{ foo: [{bar: 1, baz: 'a'}, {bar: 2, baz: 'b'}, {bar:3, baz: 'c'}], eoo: { doo: { car: 1, caz: 'a'} } }");
+        ScenarioContext ctx = getContext();
+        ctx.vars.put("myJson", doc);
+        ScriptValue myJson = ctx.vars.get("myJson");
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
+        assertFalse(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 4}, {bar:3}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1, baz: 'a'}]", ctx).pass);
+        assertFalse(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1, baz: 'a', 'baq': 'b'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar:3, baz: 'c'}]", ctx).pass);
+
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{eoo: '#ignore'}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{eoo: { doo: {car: 1} } }", ctx).pass);
+        assertFalse(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{eoo: { doo: {car: 'a'} } }", ctx).pass);
+
     }
 
     @Test

--- a/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/ScriptTest.java
@@ -389,15 +389,28 @@ public class ScriptTest {
         assertTrue(Script.matchJsonOrObject(MatchType.NOT_CONTAINS, myJson, "$.foo", "[{bar: 9, baz: 'z'}, {bar: 99, baz: 'zz'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 1, baz: 'a'}, {bar: 2, baz: 'b'}, {bar:3, baz: 'c'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ANY, myJson, "$.foo", "[{bar: 9, baz: 'z'}, {bar: 2, baz: 'b'}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar:3, baz: 'c'}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{bar: 1}, {bar: 2}, {bar:3}]}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar:3, baz: 'c'}]}", ctx).pass);
+
         // shuffle
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar:3, baz: 'c'}]}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 2, baz: 'b'}, {bar:3, baz: 'c'}, {bar: 1, baz: 'a'}]", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar:3, baz: 'c'}]", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.CONTAINS_ONLY, myJson, "$.foo", "[{bar: 1, baz: 'a'}, {bar: 2, baz: 'b'}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_EQUALS, myJson, "$.foo", "{bar:'#number', baz:'#string'}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{bar: 1}, {bar: 2}, {bar:3}]", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_CONTAINS, myJson, "$.foo", "{bar:'#number'}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_CONTAINS, myJson, "$.foo", "{baz:'#string'}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]}", ctx).pass);
         assertTrue(Script.matchJsonOrObject(MatchType.EACH_NOT_CONTAINS, myJson, "$.foo", "{baz:'z'}", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.EACH_NOT_CONTAINS, myJson, "$.foo", "{baz:'a'}", ctx).pass);
         assertFalse(Script.matchJsonOrObject(MatchType.EACH_EQUALS, myJson, "$.foo", "{bar:'#? _ < 3',  baz:'#string'}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$", "{foo: [{bar: 1}, {bar: 2}, {bar:3}]}", ctx).pass);
+        assertTrue(Script.matchJsonOrObject(MatchType.CONTAINS_DEEP, myJson, "$.foo", "[{baz: 'a'}, {bar: 2}, {bar:3, baz: 'c'}]", ctx).pass);
     }
 
     @Test

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/demos/js-arrays.feature
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/demos/js-arrays.feature
@@ -311,10 +311,15 @@ Scenario: comparing 2 payloads
     * def bar = { baz: 'ban', hello: 'world' }
     * match foo == bar
 
-Scenario: contains will recurse
+Scenario: contains deep will recurse nested json
     * def original = { a: 1, b: 2, c: 3, d: { a: 1, b: 2 } }
     * def expected = { a: 1, c: 3, d: { b: 2 } }
-    * match original contains expected
+    * match original contains deep expected
+
+Scenario: contains deep will recurse nested array
+    * def original = { a: 1, arr: [ { b: 2, c: 3 }, { b: 3, c: 4 } ] }
+    * def expected = { a: 1, arr: [ { b: 2 }, { c: 4 } ] }
+    * match original contains deep expected
 
 Scenario: contains will recurse in reverse !
     * def original = { "a": { "b": { "c": { "d":1, "e":2 } } } }


### PR DESCRIPTION
### Description

As discussed in issue #826 and #925, the `contains` during a `match` operation are restricted to equals when the nested object are of type array. Adding support to `contains` recursively even for nested objects. 

Example:
```gherkin
Scenario: Deep contains
    Given def original = { a: 1, [ { b: 3, c: 4 }, d: { b: 1, c: 2 } ] }
    And def expected = { a: 1, [ { b: 3 }, d: { b: 1 } ] }
    # using contains it fails to match.
    # Then match original contains expected
    Then match original contains deep expected
```

- Relevant Issues : #826 #925  
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
