### PR TITLE
[robot] added select() for combo-box value selection

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -823,7 +823,7 @@ Just triggers a click event on the DOM element:
 Also see [`submit()`](#submit) and [`mouse()`](#mouse).
 
 ## `select()`
-You can use this for plain-vanilla `<select>` boxes that have not been overly "ehnanced" by JavaScript. Nowadays, most "select" (or "multi-select") user experiences are JavaScript widgets, so you would be needing to fire a [`click()`](#click) or two to get things done. But if you are really dealing with an HTML `<select>`, then read on.
+You can use this for plain-vanilla `<select>` boxes that have not been overly "enhanced" by JavaScript. Nowadays, most "select" (or "multi-select") user experiences are JavaScript widgets, so you would be needing to fire a [`click()`](#click) or two to get things done. But if you are really dealing with an HTML `<select>`, then read on.
 
 There are four variations and use the [locator](#locators) prefix conventions for *exact* and *contains* matches against the `<option>` text-content.
 

--- a/karate-robot/README.md
+++ b/karate-robot/README.md
@@ -257,6 +257,9 @@ If you need to simulate key combinations, just ensure that the [modifier keys](#
 * input(Key.META + 't')
 ```
 
+## `select()`
+To select from drop-down, for item type elements.
+
 ## `press()`
 A mouse press that will be held down, useful for simulating a drag and drop operation.
 

--- a/karate-robot/src/main/java/com/intuit/karate/robot/Element.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/Element.java
@@ -130,4 +130,6 @@ public interface Element {
     
     String getDebugString();
 
+    Element select();
+
 }

--- a/karate-robot/src/main/java/com/intuit/karate/robot/ImageElement.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/ImageElement.java
@@ -144,6 +144,11 @@ public class ImageElement implements Element {
     @Override
     public String getDebugString() {
         return getName();
-    }        
+    }
+
+    @Override
+    public Element select() {
+        return this;
+    }
 
 }

--- a/karate-robot/src/main/java/com/intuit/karate/robot/MissingElement.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/MissingElement.java
@@ -139,4 +139,9 @@ public class MissingElement implements Element {
         return "(missing element)";
     }
 
+    @Override
+    public Element select() {
+        return this;
+    }
+
 }

--- a/karate-robot/src/main/java/com/intuit/karate/robot/win/IUIAutomationSelectionItemPattern.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/win/IUIAutomationSelectionItemPattern.java
@@ -1,0 +1,10 @@
+package com.intuit.karate.robot.win;
+
+/**
+ * @author babusekaran
+ */
+public class IUIAutomationSelectionItemPattern extends IUIAutomationBase {
+
+    public void select() { invoke("Select");}
+
+}

--- a/karate-robot/src/main/java/com/intuit/karate/robot/win/Pattern.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/win/Pattern.java
@@ -42,7 +42,7 @@ public enum Pattern {
     GridItem(10007),
     MultipleView(10008),
     Window(10009),
-    SelectionItem(10010),
+    SelectionItem(10010, IUIAutomationSelectionItemPattern.class),
     Dock(10011),
     Table(10012),
     TableItem(10013),

--- a/karate-robot/src/main/java/com/intuit/karate/robot/win/WinElement.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/win/WinElement.java
@@ -193,6 +193,13 @@ public class WinElement implements Element {
     @Override
     public String toString() {
         return getDebugString();
-    }        
+    }
+
+    @Override
+    public Element select() {
+        ((IUIAutomationSelectionItemPattern) e.getCurrentPattern(IUIAutomationSelectionItemPattern.class))
+                .select();
+        return this;
+    }
 
 }


### PR DESCRIPTION
This is a basic implementation for selecting the `item` type element from a Combobox. added `select()` function in `Element` since this is different from `click()`

eg:
```cucumber
* locate("{combobox.ComboBox}").click()
* locate("{listitem.ListBoxItem}MPEG-4").select()
```

Implemented and tested on **Windows**
for mac and Linux currently returning element without any action

![karateRobot](https://user-images.githubusercontent.com/26348282/82752775-bd187600-9dc0-11ea-84b0-9b4bf9e60235.gif)

- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
