### PR TITLE
Multiple mock feature files and scenario precedence rules

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
@@ -76,6 +76,9 @@ public class ScriptBindings implements Bindings {
     public static final String HEADER_CONTAINS = "headerContains";
     public static final String PARAM_VALUE = "paramValue";
     public static final String PATH_PARAMS = "pathParams";
+    public static final String PATH_MATCH_SCORES = "pathMatchScores";
+    public static final String METHOD_MATCH = "methodMatch";
+    public static final String HEADERS_MATCH_SCORE = "headersMatchScore";
     public static final String BODY_PATH = "bodyPath";
     public static final String SERVER_PORT = "serverPort";
 

--- a/karate-core/src/main/java/com/intuit/karate/ScriptValue.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptValue.java
@@ -45,6 +45,7 @@ public class ScriptValue {
 
     public static final ScriptValue NULL = new ScriptValue(null);
     public static final ScriptValue FALSE = new ScriptValue(false);
+    public static final ScriptValue ZERO = new ScriptValue(0);
 
     public static enum Type {
         NULL,

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -26,18 +26,18 @@ package com.intuit.karate.core;
 import com.intuit.karate.CallContext;
 import com.intuit.karate.Script;
 import com.intuit.karate.ScriptBindings;
-import com.intuit.karate.FileUtils;
-import com.intuit.karate.JsonUtils;
-import com.intuit.karate.Match;
 import com.intuit.karate.ScriptValue;
 import com.intuit.karate.ScriptValueMap;
 import com.intuit.karate.StepActions;
 import com.intuit.karate.StringUtils;
-import com.intuit.karate.XmlUtils;
 import com.intuit.karate.exception.KarateException;
 import com.intuit.karate.http.HttpRequest;
 import com.intuit.karate.http.HttpResponse;
 import com.intuit.karate.http.HttpUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -47,13 +47,49 @@ import java.util.Map;
  */
 public class FeatureBackend {
 
+    private static final String ALLOWED_METHODS = "GET, HEAD, POST, PUT, DELETE, PATCH";
+
     private final Feature feature;
     private final StepActions actions;
 
-    private boolean corsEnabled;
-
     private final ScenarioContext context;
     private final String featureName;
+
+    public static class FeatureScenarioMatch {
+        private final FeatureBackend featureBackend;
+        private final Scenario scenario;
+        private final List<Integer> scores;
+
+        public FeatureScenarioMatch(FeatureBackend featureBackend, Scenario scenario, List<Integer> scores) {
+            this.scenario = scenario;
+            this.scores = Collections.unmodifiableList(scores);
+            this.featureBackend = featureBackend;
+        }
+
+        public FeatureBackend getFeatureBackend() {
+            return featureBackend;
+        }
+
+        public Scenario getScenario() {
+            return scenario;
+        }
+
+        public List<Integer> getScores() {
+            return scores;
+        }
+
+        public int compareScores(FeatureScenarioMatch other) {
+            for(int i = 0; i < scores.size(); i++) {
+                Integer score = scores.get(i);
+                Integer otherScore = other.getScores().get(i);
+                int compareTo = score.compareTo(otherScore);
+                if(compareTo != 0) {
+                    return compareTo;
+                }
+            }
+            return 0;
+        }
+    }
 
     private static void putBinding(String name, ScenarioContext context) {
         String function = "function(a){ return " + ScriptBindings.KARATE + "." + name + "(a) }";
@@ -65,12 +101,12 @@ public class FeatureBackend {
         context.vars.put(name, Script.evalJsExpression(function, context));
     }    
 
-    public boolean isCorsEnabled() {
-        return corsEnabled;
-    }
-
     public ScenarioContext getContext() {
         return context;
+    }
+
+    public String getFeatureName() {
+        return featureName;
     }
 
     public FeatureBackend(Feature feature) {
@@ -105,15 +141,31 @@ public class FeatureBackend {
                 }
             }
         }
-        // this is a special case, we support the auto-handling of cors
-        // only if '* configure cors = true' has been done in the Background
-        corsEnabled = context.getConfig().isCorsEnabled(); 
-        context.logger.info("backend initialized");
+        context.logger.info("backend {} initialized", featureName);
     }
 
-    public ScriptValueMap handle(ScriptValueMap args) {
-        boolean matched = false;
+    public ScriptValueMap handle(ScriptValueMap args, Scenario scenario) {
         context.vars.putAll(args);
+        // This forces context to be refreshed by matching scenarios context variables
+        isMatchingScenario(scenario);
+        for (Step step : scenario.getSteps()) {
+            Result result = Engine.executeStep(step, actions);
+            if (result.isAborted()) {
+                context.logger.debug("abort at {}:{}", featureName, step.getLine());
+                break;
+            }
+            if (result.isFailed()) {
+                String message = "server-side scenario failed - " + featureName + ":" + step.getLine();
+                context.logger.error(message);
+                throw new KarateException(message, result.getError());
+            }
+        }
+        return context.vars;
+    }
+
+    public List<FeatureScenarioMatch> getMatchingScenarios(ScriptValueMap args) {
+        context.vars.putAll(args);
+        List<FeatureScenarioMatch> matchingScenarios = new ArrayList<>();
         for (FeatureSection fs : feature.getSections()) {
             if (fs.isOutline()) {
                 context.logger.warn("skipping scenario outline - {}:{}", featureName, fs.getScenarioOutline().getLine());
@@ -121,34 +173,26 @@ public class FeatureBackend {
             }
             Scenario scenario = fs.getScenario();
             if (isMatchingScenario(scenario)) {
-                matched = true;
-                for (Step step : scenario.getSteps()) {
-                    Result result = Engine.executeStep(step, actions);
-                    if (result.isAborted()) {
-                        context.logger.debug("abort at {}:{}", featureName, step.getLine());
-                        break;
-                    }
-                    if (result.isFailed()) {
-                        String message = "server-side scenario failed - " + featureName + ":" + step.getLine();
-                        context.logger.error(message);
-                        throw new KarateException(message, result.getError());
-                    }
-                }
-                break; // process only first matching scenario
+                List<Integer> scores = new ArrayList<>();
+                ScriptValue pathMatchScoresValue = context.vars.getOrDefault(ScriptBindings.PATH_MATCH_SCORES, ScriptValue.NULL);
+                boolean methodMatch = context.vars.getOrDefault(ScriptBindings.METHOD_MATCH, ScriptValue.FALSE).getValue(Boolean.class);
+                int headersMatchScore = context.vars.getOrDefault(ScriptBindings.HEADERS_MATCH_SCORE, ScriptValue.ZERO).getAsInt();
+
+                scores.addAll(pathMatchScoresValue.isNull() ? Arrays.asList(0, 0, 0) : pathMatchScoresValue.getAsList());
+                scores.add(methodMatch ? 1 : 0);
+                scores.add(headersMatchScore);
+
+                matchingScenarios.add(new FeatureScenarioMatch(this, scenario, scores));
             }
         }
-        if (!matched) {
-            context.logger.warn("no scenarios matched");
-        }
-        return context.vars;
+        return matchingScenarios;
     }
 
     private boolean isMatchingScenario(Scenario scenario) {
-        String expression = StringUtils.trimToNull(scenario.getName() + scenario.getDescription());
-        if (expression == null) {
-            context.logger.debug("scenario matched: (empty)");
-            return true;
+        if(isDefaultScenario(scenario)) {
+            return false;
         }
+        String expression = StringUtils.trimToNull(scenario.getName() + scenario.getDescription());
         try {
             ScriptValue sv = Script.evalJsExpression(expression, context);
             if (sv.isBooleanTrue()) {
@@ -163,12 +207,26 @@ public class FeatureBackend {
             return false;
         }
     }
+
+    public Scenario getDefaultScenario(ScriptValueMap args) {
+        for (FeatureSection fs : feature.getSections()) {
+
+            Scenario scenario = fs.getScenario();
+            if (isDefaultScenario(scenario)) {
+                return scenario;
+            }
+        }
+        return null;
+    }
+
+    private boolean isDefaultScenario(Scenario scenario) {
+        return StringUtils.trimToNull(scenario.getName() + scenario.getDescription()) == null;
+    }
     
     private static final String VAR_AFTER_SCENARIO = "afterScenario";
-    private static final String ALLOWED_METHODS = "GET, HEAD, POST, PUT, DELETE, PATCH";
-    
-    public HttpResponse buildResponse(HttpRequest request, long startTime) {
-        if (corsEnabled && "OPTIONS".equals(request.getMethod())) {
+
+    public HttpResponse corsCheck(HttpRequest request, long startTime) {
+        if (context.getConfig().isCorsEnabled()) {
             HttpResponse response = new HttpResponse(startTime, System.currentTimeMillis());
             response.setStatus(200);
             response.addHeader(HttpUtils.HEADER_ALLOW, ALLOWED_METHODS);
@@ -177,42 +235,19 @@ public class FeatureBackend {
             List requestHeaders = request.getHeaders().get(HttpUtils.HEADER_AC_REQUEST_HEADERS);
             if (requestHeaders != null) {
                 response.putHeader(HttpUtils.HEADER_AC_ALLOW_HEADERS, requestHeaders);
-            }            
+            }
             return response;
         }
-        Match match = new Match()
-                .text(ScriptValueMap.VAR_REQUEST_URL_BASE, request.getUrlBase())
-                .text(ScriptValueMap.VAR_REQUEST_URI, request.getUri())
-                .text(ScriptValueMap.VAR_REQUEST_METHOD, request.getMethod())
-                .def(ScriptValueMap.VAR_REQUEST_HEADERS, request.getHeaders())
-                .def(ScriptValueMap.VAR_RESPONSE_STATUS, 200)
-                .def(ScriptValueMap.VAR_REQUEST_PARAMS, request.getParams());
-        byte[] requestBytes = request.getBody();
-        if (requestBytes != null) {
-            match.def(ScriptValueMap.VAR_REQUEST_BYTES, requestBytes);
-            String requestString = FileUtils.toString(requestBytes);
-            Object requestBody = requestString;
-            if (Script.isJson(requestString)) {
-                try {
-                    requestBody = JsonUtils.toJsonDoc(requestString);
-                } catch (Exception e) {
-                    context.logger.warn("json parsing failed, request data type set to string: {}", e.getMessage());
-                }
-            } else if (Script.isXml(requestString)) {
-                try {
-                    requestBody = XmlUtils.toXmlDoc(requestString);
-                } catch (Exception e) {
-                    context.logger.warn("xml parsing failed, request data type set to string: {}", e.getMessage());
-                }
-            }
-            match.def(ScriptValueMap.VAR_REQUEST, requestBody);
-        }
+        return null;
+    }
+
+    public HttpResponse buildResponse(HttpRequest request, long startTime, Scenario scenario, ScriptValueMap args) {
         ScriptValue responseValue, responseStatusValue, responseHeaders, afterScenario;
         Map<String, Object> responseHeadersMap, configResponseHeadersMap;
         // this is a sledgehammer approach to concurrency !
         // which is why for simulating 'delay', users should use the VAR_AFTER_SCENARIO (see end)
         synchronized (this) { // BEGIN TRANSACTION !
-            ScriptValueMap result = handle(match.vars());
+            ScriptValueMap result = handle(args, scenario);
             ScriptValue configResponseHeaders = context.getConfig().getResponseHeaders();
             responseValue = result.remove(ScriptValueMap.VAR_RESPONSE);
             responseStatusValue = result.remove(ScriptValueMap.VAR_RESPONSE_STATUS);
@@ -254,7 +289,7 @@ public class FeatureBackend {
         if (responseValue != null && (responseHeadersMap == null || !responseHeadersMap.containsKey(HttpUtils.HEADER_CONTENT_TYPE))) {
             response.addHeader(HttpUtils.HEADER_CONTENT_TYPE, HttpUtils.getContentType(responseValue));
         }        
-        if (corsEnabled) {
+        if (context.getConfig().isCorsEnabled()) {
             response.addHeader(HttpUtils.HEADER_AC_ALLOW_ORIGIN, "*");
         }
         // functions here are outside of the 'transaction' and should not mutate global state !
@@ -263,6 +298,6 @@ public class FeatureBackend {
             afterScenario.invokeFunction(context, null);
         }
         return response;
-    }    
+    }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
@@ -1,0 +1,183 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Intuit Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.intuit.karate.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.intuit.karate.FileUtils;
+import com.intuit.karate.JsonUtils;
+import com.intuit.karate.Match;
+import com.intuit.karate.Script;
+import com.intuit.karate.ScriptValueMap;
+import com.intuit.karate.XmlUtils;
+import com.intuit.karate.http.HttpRequest;
+import com.intuit.karate.http.HttpResponse;
+import com.intuit.karate.http.HttpUtils;
+
+/**
+ * A wrapper class to run multiple mock files, picking first match based on path, method, header.
+ *
+ */
+public class FeaturesBackend {
+
+    private final List<FeatureBackend> featureBackends;
+    private static final String ALLOWED_METHODS = "GET, HEAD, POST, PUT, DELETE, PATCH";
+    private static final String DUMMY_FEATURE =
+            "@ignore\nFeature:\n\nBackground:\n\nScenario:\n\n";
+
+//    private final Feature serverFeature;
+//    private final StepActions actions;
+//    private final ScenarioContext context;
+
+    public FeaturesBackend(Feature feature) {
+        this(new Feature[]{feature});
+    }
+
+    public FeaturesBackend(Feature[] features) {
+        this(features, null);
+    }
+
+    public FeaturesBackend(Feature[] features, Map<String, Object> arg) {
+        this.featureBackends = Arrays.stream(features).map((feature) -> new FeatureBackend(feature, arg)).collect(
+                Collectors.toList());
+//        serverFeature = FeatureParser.parseText(null, DUMMY_FEATURE);
+//        serverFeature.setName(this.getClass().getName());
+//        serverFeature.setCallName(this.getClass().getName());
+//        CallContext callContext = new CallContext(null, false);
+//        FeatureContext featureContext = new FeatureContext(null, serverFeature, null);
+//        actions = new StepActions(featureContext, callContext, null, null);
+//        context = actions.context;
+        //TODO would be good to pass the root context to backends
+
+        getContext().logger.info("all backends initialized");
+    }
+
+    public boolean isCorsEnabled() {
+        return featureBackends.stream().anyMatch((fb) -> fb.getContext().getConfig().isCorsEnabled());
+    }
+
+    public ScenarioContext getContext() {
+        return featureBackends.get(0).getContext();
+    }
+
+    public HttpResponse buildResponse(HttpRequest request, long startTime) {
+        if("OPTIONS".equals(request.getMethod()) && isCorsEnabled()) {
+            return corsCheck(request, startTime);
+        }
+        //This is not expected to be an actual scenario
+        Match match = new Match()
+                .text(ScriptValueMap.VAR_REQUEST_URL_BASE, request.getUrlBase())
+                .text(ScriptValueMap.VAR_REQUEST_URI, request.getUri())
+                .text(ScriptValueMap.VAR_REQUEST_METHOD, request.getMethod())
+                .def(ScriptValueMap.VAR_REQUEST_HEADERS, request.getHeaders())
+                .def(ScriptValueMap.VAR_RESPONSE_STATUS, 200)
+                .def(ScriptValueMap.VAR_REQUEST_PARAMS, request.getParams());
+        byte[] requestBytes = request.getBody();
+        if (requestBytes != null) {
+            match.def(ScriptValueMap.VAR_REQUEST_BYTES, requestBytes);
+            String requestString = FileUtils.toString(requestBytes);
+            Object requestBody = requestString;
+            if (Script.isJson(requestString)) {
+                try {
+                    requestBody = JsonUtils.toJsonDoc(requestString);
+                } catch (Exception e) {
+                    getContext().logger.warn("json parsing failed, request data type set to string: {}", e.getMessage());
+                }
+            } else if (Script.isXml(requestString)) {
+                try {
+                    requestBody = XmlUtils.toXmlDoc(requestString);
+                } catch (Exception e) {
+                    getContext().logger.warn("xml parsing failed, request data type set to string: {}", e.getMessage());
+                }
+            }
+            match.def(ScriptValueMap.VAR_REQUEST, requestBody);
+        }
+
+
+        FeatureBackend.FeatureScenarioMatch matchingInfo = getMatchingScenario(match.vars());
+        FeatureBackend matchingFeature = matchingInfo.getFeatureBackend();
+        Scenario matchingScenario = matchingInfo.getScenario();
+
+        return matchingFeature.buildResponse(request, startTime, matchingScenario, match.vars());
+    }
+
+    public HttpResponse corsCheck(HttpRequest request, long startTime) {
+        HttpResponse response = new HttpResponse(startTime, System.currentTimeMillis());
+        response.setStatus(200);
+        response.addHeader(HttpUtils.HEADER_ALLOW, ALLOWED_METHODS);
+        response.addHeader(HttpUtils.HEADER_AC_ALLOW_ORIGIN, "*");
+        response.addHeader(HttpUtils.HEADER_AC_ALLOW_METHODS, ALLOWED_METHODS);
+        List requestHeaders = request.getHeaders().get(HttpUtils.HEADER_AC_REQUEST_HEADERS);
+        if (requestHeaders != null) {
+            response.putHeader(HttpUtils.HEADER_AC_ALLOW_HEADERS, requestHeaders);
+        }
+        return response;
+    }
+
+    public ScriptValueMap handle(ScriptValueMap args) {
+        FeatureBackend.FeatureScenarioMatch matchingInfo = getMatchingScenario(args);
+        //TODO what happens when no matching scenario exists?
+        return matchingInfo.getFeatureBackend().handle(args, matchingInfo.getScenario());
+    }
+
+    /**
+     * @param args
+     * @return
+     */
+    public FeatureBackend.FeatureScenarioMatch getMatchingScenario(ScriptValueMap args) {
+        FeatureBackend.FeatureScenarioMatch matching = null;
+        List<FeatureBackend.FeatureScenarioMatch> matches = new ArrayList<>();
+        List<FeatureBackend.FeatureScenarioMatch> defaults = new ArrayList<>();
+        for(FeatureBackend featureBackend: featureBackends) {
+            //This can be optimised by saying give me the first one
+            List<FeatureBackend.FeatureScenarioMatch> featureMatches = featureBackend.getMatchingScenarios(args);
+            Scenario defaultMatch = featureBackend.getDefaultScenario(args);
+
+            matches.addAll(featureMatches);
+            if(defaultMatch != null)
+                defaults.add(new FeatureBackend.FeatureScenarioMatch(featureBackend, defaultMatch, Arrays.asList(0, 0, 0, 0, 0)));
+
+        }
+        if(matches.isEmpty() && defaults.isEmpty()) {
+            getContext().logger.error("no scenarios matched request");
+            return null;
+        }
+        else {
+            matching = matches.stream().max((left, right) -> left.compareScores(right)).orElse(null);
+            if(matching == null) {
+                matching = defaults.stream().findFirst().get();
+                getContext().logger.debug("scenario defaulted: {}#{}", matching.getFeatureBackend().getFeatureName(), matching.getScenario().getName());
+            }
+            else {
+                getContext().logger.debug("scenario picked: {}#{}", matching.getFeatureBackend().getFeatureName(), matching.getScenario().getName());
+            }
+
+        }
+        return matching;
+    }
+}

--- a/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,40 +66,40 @@ import org.w3c.dom.Node;
  * @author pthomas3
  */
 public class ScriptBridge implements PerfContext {
-    
+
     private static final Object GLOBALS_LOCK = new Object();
     private static final Map<String, Object> GLOBALS = new HashMap();
-    
+
     public final ScenarioContext context;
-    
+
     private static final ThreadLocal<ScenarioContext> CURRENT_CONTEXT = new ThreadLocal();
-    
+
     public ScriptBridge(ScenarioContext context) {
         this.context = context;
         CURRENT_CONTEXT.set(context); // needed for call() edge case
     }
-    
+
     public ScenarioContext getContext() {
         return context;
     }
-    
+
     public void configure(String key, Object o) {
         context.configure(key, new ScriptValue(o));
     }
-    
+
     public Object read(String fileName) {
         return context.read.apply(fileName);
     }
-    
+
     public String readAsString(String fileName) {
         return FileUtils.readFileAsString(fileName, context);
     }
-    
+
     public String pretty(Object o) {
         ScriptValue sv = new ScriptValue(o);
         return sv.getAsPrettyString();
     }
-    
+
     public String prettyXml(Object o) {
         ScriptValue sv = new ScriptValue(o);
         if (sv.isXml()) {
@@ -113,11 +114,11 @@ public class ScriptBridge implements PerfContext {
             return XmlUtils.toString(doc, true);
         }
     }
-    
+
     public void set(String name, Object o) {
         context.vars.put(name, o);
     }
-    
+
     public void setXml(String name, String xml) {
         context.vars.put(name, XmlUtils.toXmlDoc(xml));
     }
@@ -136,7 +137,7 @@ public class ScriptBridge implements PerfContext {
     public void remove(String name, String path) {
         Script.removeValueByPath(name, path, context);
     }
-    
+
     public Object get(String exp) {
         ScriptValue sv;
         try {
@@ -151,32 +152,32 @@ public class ScriptBridge implements PerfContext {
             return null;
         }
     }
-    
+
     public Object get(String exp, Object defaultValue) {
         Object result = get(exp);
         return result == null ? defaultValue : result;
     }
-    
+
     public int sizeOf(List list) {
         return list.size();
     }
-    
+
     public int sizeOf(Map map) {
         return map.size();
-    }    
-    
+    }
+
     public List keysOf(Map map) {
         return new ArrayList(map.keySet());
     }
-    
+
     public List valuesOf(List list) {
         return list;
     }
-    
+
     public List valuesOf(Map map) {
         return new ArrayList(map.values());
-    }    
-    
+    }
+
     public Map<String, Object> match(Object actual, Object expected) {
         AssertionResult result = Script.matchNestedObject('.', "$", MatchType.EQUALS, actual, null, actual, expected, context);
         Map<String, Object> map = new HashMap(2);
@@ -184,7 +185,7 @@ public class ScriptBridge implements PerfContext {
         map.put("message", result.message);
         return map;
     }
-    
+
     public void forEach(Map<String, Object> map, ScriptObjectMirror som) {
         if (map == null) {
             return;
@@ -195,7 +196,7 @@ public class ScriptBridge implements PerfContext {
         AtomicInteger i = new AtomicInteger();
         map.forEach((k, v) -> som.call(som, k, v, i.getAndIncrement()));
     }
-    
+
     public void forEach(List list, ScriptObjectMirror som) {
         if (list == null) {
             return;
@@ -207,7 +208,7 @@ public class ScriptBridge implements PerfContext {
             som.call(som, list.get(i), i);
         }
     }
-    
+
     public Object map(List list, ScriptObjectMirror som) {
         if (list == null) {
             return new ArrayList();
@@ -222,7 +223,7 @@ public class ScriptBridge implements PerfContext {
         }
         return res;
     }
-    
+
     public Object filter(List list, ScriptObjectMirror som) {
         if (list == null) {
             return new ArrayList();
@@ -248,7 +249,7 @@ public class ScriptBridge implements PerfContext {
         }
         return res;
     }
-    
+
     public Object filterKeys(Map<String, Object> map, Map<String, Object> filter) {
         if (map == null) {
             return new LinkedHashMap();
@@ -264,12 +265,12 @@ public class ScriptBridge implements PerfContext {
         });
         return out;
     }
-    
+
     public Object filterKeys(Map<String, Object> map, List keys) {
         return filterKeys(map, keys.toArray());
     }
-    
-    public Object filterKeys(Map map, Object ... keys) {
+
+    public Object filterKeys(Map map, Object... keys) {
         if (map == null) {
             return new LinkedHashMap();
         }
@@ -277,11 +278,11 @@ public class ScriptBridge implements PerfContext {
         for (Object key : keys) {
             if (map.containsKey(key)) {
                 out.put(key, map.get(key));
-            }            
+            }
         }
         return out;
-    }    
-    
+    }
+
     public Object repeat(int n, ScriptObjectMirror som) {
         if (!som.isFunction()) {
             throw new RuntimeException("not a JS function: " + som);
@@ -293,7 +294,7 @@ public class ScriptBridge implements PerfContext {
         }
         return res;
     }
-    
+
     public Object mapWithKey(List list, String key) {
         if (list == null) {
             return new ArrayList();
@@ -306,7 +307,7 @@ public class ScriptBridge implements PerfContext {
         }
         return res;
     }
-    
+
     public Object merge(Map... maps) {
         Map out = new LinkedHashMap();
         if (maps == null) {
@@ -320,7 +321,7 @@ public class ScriptBridge implements PerfContext {
         }
         return out;
     }
-    
+
     public Object append(Object... items) {
         List out = new ArrayList();
         if (items == null) {
@@ -345,7 +346,7 @@ public class ScriptBridge implements PerfContext {
         }
         return out;
     }
-    
+
     public List appendTo(String name, Object... values) {
         ScriptValue sv = context.vars.get(name);
         if (sv == null || !sv.isListLike()) {
@@ -355,7 +356,7 @@ public class ScriptBridge implements PerfContext {
         context.vars.put(name, list);
         return list;
     }
-    
+
     public List appendTo(List list, Object... values) {
         for (Object o : values) {
             if (o instanceof Collection) {
@@ -363,10 +364,10 @@ public class ScriptBridge implements PerfContext {
             } else {
                 list.add(o);
             }
-        }        
+        }
         return list;
-    }    
-    
+    }
+
     public Object jsonPath(Object o, String exp) {
         DocumentContext doc;
         if (o instanceof DocumentContext) {
@@ -376,12 +377,12 @@ public class ScriptBridge implements PerfContext {
         }
         return doc.read(exp);
     }
-    
+
     public Object lowerCase(Object o) {
         ScriptValue sv = new ScriptValue(o);
         return sv.toLowerCase();
     }
-    
+
     public Object xmlPath(Object o, String path) {
         if (!(o instanceof Node)) {
             if (o instanceof Map) {
@@ -393,13 +394,13 @@ public class ScriptBridge implements PerfContext {
         ScriptValue sv = Script.evalXmlPathOnXmlNode((Node) o, path);
         return sv.getValue();
     }
-    
+
     public Object toBean(Object o, String className) {
         ScriptValue sv = new ScriptValue(o);
         DocumentContext doc = Script.toJsonDoc(sv, context);
         return JsonUtils.fromJson(doc.jsonString(), className);
     }
-    
+
     public Object toMap(Object o) {
         if (o instanceof Map) {
             Map<String, Object> src = (Map) o;
@@ -407,19 +408,19 @@ public class ScriptBridge implements PerfContext {
         }
         return o;
     }
-    
+
     public Object toList(Object o) {
         if (o instanceof List) {
             List src = (List) o;
             return new ArrayList(src);
         }
         return o;
-    }    
-    
+    }
+
     public Object toJson(Object o) {
         return toJson(o, false);
     }
-    
+
     public Object toJson(Object o, boolean removeNulls) {
         Object result = JsonUtils.toJsonDoc(o).read("$");
         if (removeNulls) {
@@ -427,11 +428,11 @@ public class ScriptBridge implements PerfContext {
         }
         return result;
     }
-    
+
     public Object call(String fileName) {
         return call(fileName, null);
     }
-    
+
     public Object call(String fileName, Object arg) {
         ScriptValue sv = FileUtils.readFile(fileName, context);
         switch (sv.getType()) {
@@ -448,11 +449,11 @@ public class ScriptBridge implements PerfContext {
                 return null;
         }
     }
-    
+
     public Object callSingle(String fileName) {
         return callSingle(fileName, null);
     }
-    
+
     public Object callSingle(String fileName, Object arg) {
         if (GLOBALS.containsKey(fileName)) {
             context.logger.trace("callSingle cache hit: {}", fileName);
@@ -474,11 +475,11 @@ public class ScriptBridge implements PerfContext {
             return result;
         }
     }
-    
+
     public HttpRequest getPrevRequest() {
         return context.getPrevRequest();
     }
-    
+
     public String exec(String command) {
         Runtime runtime = Runtime.getRuntime();
         try {
@@ -488,29 +489,29 @@ public class ScriptBridge implements PerfContext {
             throw new RuntimeException(e);
         }
     }
-    
+
     public Object eval(String exp) {
         ScriptValue sv = Script.evalJsExpression(exp, context);
         return sv.getValue();
     }
-    
+
     public List<String> getTags() {
         return context.tags;
     }
-    
+
     public Map<String, List<String>> getTagValues() {
         return context.tagValues;
     }
-    
+
     public Map<String, Object> getInfo() {
         DocumentContext doc = JsonUtils.toJsonDoc(context.scenarioInfo);
         return doc.read("$");
     }
-    
+
     public void proceed() {
         proceed(null);
     }
-    
+
     public void proceed(String requestUrlBase) {
         HttpRequestBuilder request = new HttpRequestBuilder();
         String urlBase = requestUrlBase == null ? getAsString(ScriptValueMap.VAR_REQUEST_URL_BASE) : requestUrlBase;
@@ -525,11 +526,11 @@ public class ScriptBridge implements PerfContext {
         context.setPrevResponse(response);
         context.updateResponseVars();
     }
-    
+
     public void abort() {
         throw new KarateAbortException(null);
     }
-    
+
     public void embed(Object o, String contentType) {
         ScriptValue sv = new ScriptValue(o);
         if (contentType == null) {
@@ -537,7 +538,7 @@ public class ScriptBridge implements PerfContext {
         }
         context.embed(sv.getAsByteArray(), contentType);
     }
-    
+
     public File write(Object o, String path) {
         ScriptValue sv = new ScriptValue(o);
         path = FileUtils.getBuildDir() + File.separator + path;
@@ -545,15 +546,15 @@ public class ScriptBridge implements PerfContext {
         FileUtils.writeToFile(file, sv.getAsByteArray());
         return file;
     }
-    
+
     public WebSocketClient webSocket(String url) {
         return webSocket(url, null, null);
     }
-    
+
     public WebSocketClient webSocket(String url, Function<String, Boolean> handler) {
         return webSocket(url, handler, null);
     }
-    
+
     public WebSocketClient webSocket(String url, Function<String, Boolean> handler, Map<String, Object> map) {
         if (handler == null) {
             handler = t -> true; // auto signal for websocket tests
@@ -562,15 +563,15 @@ public class ScriptBridge implements PerfContext {
         options.setTextHandler(handler);
         return context.webSocket(options);
     }
-    
+
     public WebSocketClient webSocketBinary(String url) {
         return webSocketBinary(url, null, null);
     }
-    
+
     public WebSocketClient webSocketBinary(String url, Function<byte[], Boolean> handler) {
         return webSocketBinary(url, handler, null);
     }
-    
+
     public WebSocketClient webSocketBinary(String url, Function<byte[], Boolean> handler, Map<String, Object> map) {
         if (handler == null) {
             handler = t -> true; // auto signal for websocket tests
@@ -579,41 +580,54 @@ public class ScriptBridge implements PerfContext {
         options.setBinaryHandler(handler);
         return context.webSocket(options);
     }
-    
+
     public void signal(Object result) {
         context.signal(result);
     }
-    
+
     public Object listen(long timeout, ScriptObjectMirror som) {
         if (!som.isFunction()) {
             throw new RuntimeException("not a JS function: " + som);
         }
         return context.listen(timeout, () -> Script.evalJsFunctionCall(som, null, context));
     }
-    
+
     public Object listen(long timeout) {
         return context.listen(timeout, null);
     }
-    
+
     private ScriptValue getValue(String name) {
         ScriptValue sv = context.vars.get(name);
         return sv == null ? ScriptValue.NULL : sv;
     }
-    
+
     private String getAsString(String name) {
         return getValue(name).getAsString();
     }
-    
+
     public boolean pathMatches(String path) {
         String uri = getAsString(ScriptValueMap.VAR_REQUEST_URI);
-        Map<String, String> map = HttpUtils.parseUriPattern(path, uri);
-        set(ScriptBindings.PATH_PARAMS, map);
-        return map != null;
+        Map<String, String> pathParams = HttpUtils.parseUriPattern(path, uri);
+        set(ScriptBindings.PATH_PARAMS, pathParams);
+        boolean matched = pathParams != null;
+
+        List<Integer> pathMatchScores = null;
+        if(matched) {
+            pathMatchScores = HttpUtils.calculatePathMatchScore(path);
+        }
+
+        set(ScriptBindings.PATH_MATCH_SCORES, pathMatchScores);
+        return matched;
     }
-    
-    public boolean methodIs(String method) {
+
+    public boolean methodIs(String... methods) {
         String actual = getAsString(ScriptValueMap.VAR_REQUEST_METHOD);
-        return actual.equalsIgnoreCase(method);
+        boolean match = Arrays.stream(methods).anyMatch((m) -> actual.equalsIgnoreCase(m));
+
+        boolean existingValue = (Boolean) get(ScriptBindings.METHOD_MATCH, Boolean.FALSE);
+        set(ScriptBindings.METHOD_MATCH, match || existingValue);
+
+        return match;
     }
     
     public Object paramValue(String name) {
@@ -642,6 +656,8 @@ public class ScriptBridge implements PerfContext {
         }
         for (String s : list) {
             if (s != null && s.contains(test)) {
+                int existingValue = (int) get(ScriptBindings.HEADERS_MATCH_SCORE, 0);
+                set(ScriptBindings.HEADERS_MATCH_SCORE, existingValue+1);
                 return true;
             }
         }
@@ -669,19 +685,23 @@ public class ScriptBridge implements PerfContext {
     }
     
     public FeatureServer start(String mock) {
-        return start(Collections.singletonMap("mock", mock));
+        return start(Collections.singletonMap("mock", mock == null ? null : Arrays.asList(mock)));
     }    
     
     public FeatureServer start(Map<String, Object> config) {
-        String mock = (String) config.get("mock");
-        if (mock == null) {
+        List<String> mocks = (List<String>) config.get("mock");
+        if (mocks == null || mocks.size() == 0) {
             throw new RuntimeException("'mock' is missing: " + config);
-        }        
-        ScriptValue mockSv = FileUtils.readFile(mock, context);
-        if (!mockSv.isFeature()) {
-            throw new RuntimeException("'mock' is not a feature file: " + config + ", " + mockSv);
         }
-        Feature feature = mockSv.getValue(Feature.class);        
+        List<Feature> features = new ArrayList<>();
+        for (String mock: mocks) {
+            ScriptValue mockSv = FileUtils.readFile(mock, context);
+            if (!mockSv.isFeature()) {
+                throw new RuntimeException("'mock' is not a feature file: " + config + ", " + mockSv);
+            }
+            Feature feature = mockSv.getValue(Feature.class);
+            features.add(feature);
+        }
         String certFile = (String) config.get("cert");
         String keyFile = (String) config.get("key");
         Boolean ssl = (Boolean) config.get("ssl");
@@ -702,9 +722,9 @@ public class ScriptBridge implements PerfContext {
             if (!keySv.isStream()) {
                 throw new RuntimeException("'key' is not valid: " + config + ", " + keySv);
             }
-            return new FeatureServer(feature, port, ssl, certSv.getAsStream(), keySv.getAsStream(), arg);
+            return new FeatureServer(features.toArray(new Feature[0]), port, ssl, certSv.getAsStream(), keySv.getAsStream(), arg);
         } else {
-            return new FeatureServer(feature, port, ssl, arg);
+            return new FeatureServer(features.toArray(new Feature[0]), port, ssl, arg);
         }
     }
     

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
@@ -10,13 +10,18 @@ import java.io.InputStream;
 import java.net.HttpCookie;
 import java.nio.charset.Charset;
 import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +47,10 @@ public class HttpUtils {
     public static final Set<String> HTTP_METHODS
             = Stream.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "CONNECT", "TRACE")
                     .collect(Collectors.toSet());
+
+    public static final List<Integer> DEFAULT_PATH_SCORE = Collections.unmodifiableList(Arrays.asList(0, 0, 0));
+    private static final Map<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<>();
+    private static final Map<String, List<Integer>> PATH_SCORE_CACHE = new ConcurrentHashMap<>();
 
     private HttpUtils() {
         // only static methods
@@ -166,13 +175,64 @@ public class HttpUtils {
                 continue;
             }
             if (left.startsWith("{") && left.endsWith("}")) {
-                left = left.substring(1, left.length() - 1);
+                if(left.contains(":")) {
+                    int regexStart = left.indexOf(':');
+                    String regexStr = left.substring(regexStart+1, left.length() - 1).trim();
+                    left = left.substring(1, regexStart);
+                    if(!PATTERN_CACHE.containsKey(regexStr)) {
+                        PATTERN_CACHE.put(regexStr, Pattern.compile(regexStr));
+                    }
+                    if(!PATTERN_CACHE.get(regexStr).matcher(right).matches()) {
+                        return null; //param doesnt match regex
+                    }
+                }
+                else {
+                    left = left.substring(1, left.length() - 1);
+                }
                 map.put(left, right);
             } else {
                 return null; // match failed
             }
         }
         return map;
+    }
+
+    /***
+     * Calculates path scores List(3) by using JAX-RS path matching logic:
+     *  <ol>
+     *  <li>number of literal characters</li>
+     *  <li>>path params without regex expression</li>
+     *  <li>path params with regex expression</li>
+     *  </ol>
+     **/
+    public static List<Integer> calculatePathMatchScore(String path) {
+        if(PATH_SCORE_CACHE.containsKey(path)) {
+            return PATH_SCORE_CACHE.get(path);
+        }
+        int pathScore = 0;
+        int paramScore = 0;
+        int regexScore = 0;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '{') {
+                int indexOfEnd = path.indexOf('}', i);
+                if (indexOfEnd != -1) {
+                    String pathParam = path.substring(i, ++indexOfEnd);
+                    i = indexOfEnd;
+                    boolean isRegexSpecific = pathParam.indexOf(':') != -1;
+                    if (!isRegexSpecific) {
+                        paramScore++;
+                    } else {
+                        regexScore++;
+                    }
+                    continue;
+                }
+            }
+            pathScore++;
+        }
+        List<Integer> scores = Arrays.asList(pathScore, paramScore, regexScore);
+        PATH_SCORE_CACHE.put(path, Collections.unmodifiableList(scores));
+        return scores;
     }
 
     private static final AtomicInteger BOUNDARY_COUNTER = new AtomicInteger();

--- a/karate-core/src/main/java/com/intuit/karate/netty/FeatureServer.java
+++ b/karate-core/src/main/java/com/intuit/karate/netty/FeatureServer.java
@@ -25,8 +25,8 @@ package com.intuit.karate.netty;
 
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.core.Feature;
-import com.intuit.karate.core.FeatureBackend;
 import com.intuit.karate.core.FeatureParser;
+import com.intuit.karate.core.FeaturesBackend;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -43,6 +43,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -60,11 +63,19 @@ public class FeatureServer {
     public static final String DEFAULT_KEY_NAME = "key.pem";
 
     public static FeatureServer start(File featureFile, int port, boolean ssl, Map<String, Object> arg) {
-        return new FeatureServer(featureFile, port, ssl, arg);
+        return start(Collections.singletonList(featureFile), port, ssl, arg);
+    }
+
+    public static FeatureServer start(List<File> featureFiles, int port, boolean ssl, Map<String, Object> arg) {
+        return new FeatureServer(featureFiles.toArray(new File[0]), port, ssl, arg);
     }
 
     public static FeatureServer start(File featureFile, int port, boolean ssl, File certFile, File privateKeyFile, Map<String, Object> arg) {
-        return new FeatureServer(featureFile, port, ssl, certFile, privateKeyFile, arg);
+        return start(Collections.singletonList(featureFile), port, ssl, certFile, privateKeyFile, arg);
+    }
+
+    public static FeatureServer start(List<File> featureFiles, int port, boolean ssl, File certFile, File privateKeyFile, Map<String, Object> arg) {
+        return new FeatureServer(featureFiles.toArray(new File[0]), port, ssl, certFile, privateKeyFile, arg);
     }
 
     private final Channel channel;
@@ -73,7 +84,7 @@ public class FeatureServer {
     private final boolean ssl;
     private final EventLoopGroup bossGroup;
     private final EventLoopGroup workerGroup;
-    private final FeatureBackend backend;
+    private final FeaturesBackend backend;
 
     public int getPort() {
         return port;
@@ -135,19 +146,32 @@ public class FeatureServer {
     }
 
     public FeatureServer(Feature feature, int port, boolean ssl, InputStream certStream, InputStream keyStream, Map<String, Object> arg) {
-        this(feature, port, ssl, getContextSupplierFromStreams(certStream, keyStream), arg);
+        this(new Feature[]{feature}, port, ssl, certStream, keyStream, arg);
     }
 
-    private FeatureServer(File file, int port, boolean ssl, File certificate, File privateKey, Map<String, Object> arg) {
-        this(toFeature(file), port, ssl, getContextSupplier(certificate, privateKey), arg);
+    public FeatureServer(Feature[] features, int port, boolean ssl, InputStream certStream, InputStream keyStream, Map<String, Object> arg) {
+        this(features, port, ssl, getContextSupplierFromStreams(certStream, keyStream), arg);
+    }
+
+    private FeatureServer(File[] files, int port, boolean ssl, File certificate, File privateKey, Map<String, Object> arg) {
+        this(toFeatures(files), port, ssl, getContextSupplier(certificate, privateKey), arg);
     }
 
     public FeatureServer(Feature feature, int port, boolean ssl, Map<String, Object> arg) {
-        this(feature, port, ssl, getContextSupplier(null, null), arg);
+        this(new Feature[]{feature}, port, ssl, arg);
     }
 
-    private FeatureServer(File file, int port, boolean ssl, Map<String, Object> arg) {
-        this(toFeature(file), port, ssl, getContextSupplier(null, null), arg);
+    public FeatureServer(Feature[] features, int port, boolean ssl, Map<String, Object> arg) {
+        this(features, port, ssl, getContextSupplier(null, null), arg);
+    }
+
+    private FeatureServer(File[] files, int port, boolean ssl, Map<String, Object> arg) {
+        this(toFeatures(files), port, ssl, getContextSupplier(null, null), arg);
+    }
+
+    private static Feature[] toFeatures(File[] files) {
+
+        return Arrays.stream(files).map((f) -> toFeature(f)).toArray(Feature[]::new);
     }
 
     private static Feature toFeature(File file) {
@@ -158,11 +182,11 @@ public class FeatureServer {
         return FeatureParser.parse(file);
     }
 
-    private FeatureServer(Feature feature, int requestedPort, boolean ssl, Supplier<SslContext> contextSupplier, Map<String, Object> arg) {
+    private FeatureServer(Feature[] features, int requestedPort, boolean ssl, Supplier<SslContext> contextSupplier, Map<String, Object> arg) {
         this.ssl = ssl;
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
-        backend = new FeatureBackend(feature, arg);
+        backend = new FeaturesBackend(features, arg);
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)

--- a/karate-core/src/main/java/com/intuit/karate/netty/FeatureServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/netty/FeatureServerHandler.java
@@ -25,6 +25,7 @@ package com.intuit.karate.netty;
 
 import com.intuit.karate.StringUtils;
 import com.intuit.karate.core.FeatureBackend;
+import com.intuit.karate.core.FeaturesBackend;
 import com.intuit.karate.http.HttpRequest;
 import com.intuit.karate.http.HttpResponse;
 import com.intuit.karate.http.MultiValuedMap;
@@ -56,12 +57,12 @@ import java.util.function.Supplier;
  */
 public class FeatureServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
-    private final FeatureBackend backend;
+    private final FeaturesBackend backend;
     private final Runnable stopFunction;    
     private final boolean ssl;
     private final Supplier<SslContext> contextSupplier;
 
-    public FeatureServerHandler(FeatureBackend backend, boolean ssl, Supplier<SslContext> contextSupplier, Runnable stopFunction) {
+    public FeatureServerHandler(FeaturesBackend backend, boolean ssl, Supplier<SslContext> contextSupplier, Runnable stopFunction) {
         this.backend = backend;
         this.ssl = ssl;
         this.contextSupplier = contextSupplier;
@@ -85,7 +86,7 @@ public class FeatureServerHandler extends SimpleChannelInboundHandler<FullHttpRe
             ByteBuf responseBuf = Unpooled.copiedBuffer("stopped", CharsetUtil.UTF_8);
             nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, responseBuf);
             stopFunction.run();
-        } else if (HttpMethod.CONNECT.equals(msg.method())) { // HTTPS proxy         
+        } else if (HttpMethod.CONNECT.equals(msg.method())) { // HTTPS proxy
             SslContext sslContext = contextSupplier.get();
             SslHandler sslHandler = sslContext.newHandler(ctx.alloc());
             FullHttpResponse response = NettyUtils.connectionEstablished();

--- a/karate-core/src/test/java/com/intuit/karate/core/server-path-matching.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/server-path-matching.feature
@@ -1,0 +1,41 @@
+@ignore
+Feature:
+
+Background:
+  * def currentId = 0
+  * def cats = []
+  * def nextId =
+"""
+function(){
+  var currentId = karate.get('currentId');
+  var nextId = currentId + 1;
+  karate.set('currentId', nextId);
+  return ~~nextId;
+}
+"""
+
+
+Scenario:
+  * def cat = request
+  * set cat.id = nextId()
+  * set cats[] = cat
+  * def response = cat
+
+Scenario: pathMatches('/v10/{somethingSpecific: [\\w]+}') && methodIs(['head', 'get'])
+  * def cat = request
+  * set cat.id = nextId()
+  * set cats[] = cat
+  * def response = cat
+
+
+Scenario: pathMatches('/v10/{something}') && methodIs('get')
+  * def cat = request
+  * set cat.id = nextId()
+  * set cats[] = cat
+  * def response = cat
+
+Scenario: pathMatches('/v10/cats')
+  * def cat = request
+  * set cat.id = nextId()
+  * set cats[] = cat
+  * def response = cat

--- a/karate-netty/README.md
+++ b/karate-netty/README.md
@@ -100,10 +100,10 @@ java -jar karate.jar -h
 ```
 
 ### Mock Server
-To start a mock server, the 2 mandatory arguments are the path of the feature file 'mock' `-m` and the port `-p`
+To start a mock server, the 2 mandatory arguments are the path of the feature file 'mocks' `-m` and the port `-p`
 
 ```
-java -jar karate.jar -m my-mock.feature -p 8080
+java -jar karate.jar -m my-mock.feature -m my-2nd-mock.feature -p 8080
 ```
 
 Note that this server will be able to act as an HTTPS proxy server if needed. If you need to specify a custom certificate and key combination, see below.
@@ -285,7 +285,7 @@ Teams that are using the [standalone JAR](#standalone-jar) and *don't* want to u
 
 For more control, the argument to `karate.start()` can be a JSON with the following keys expected, only the `mock` is mandatory:
 
-* `mock` - (string) path to the mock feature file, e.g. `classpath:my-mock.feature` or relative paths work just like [`read()`](https://github.com/intuit/karate#reading-files).
+* `mocks` - (string[]) path to the mock feature file, e.g. `classpath:my-mock.feature` or relative paths work just like [`read()`](https://github.com/intuit/karate#reading-files).
 * `port` - (int) defaults to `0`, see section on [embedding](#embedding) above
 * `ssl` - (boolean) defaults to `false`, see above
 * `cert` - (string) see above
@@ -404,7 +404,7 @@ Scenario: pathMatches('/v1/cats/{id}')
 JSON variable (not a function) allowing you to extract values by name. See [`pathMatches()`](#pathmatches) above.
 
 ## `methodIs()`
-Helper function that you will use a lot along with [`pathMatches()`](#pathmatches). Lower-case is fine. For example:
+Helper function that you will use a lot along with [`pathMatches()`](#pathmatches). Lower-case is fine. Allows for array of possible values. For example:
 
 ```cucumber
 Scenario: pathMatches('/v1/cats/{id}') && methodIs('get')

--- a/karate-netty/src/main/java/com/intuit/karate/Main.java
+++ b/karate-netty/src/main/java/com/intuit/karate/Main.java
@@ -32,6 +32,7 @@ import com.intuit.karate.netty.FeatureServer;
 import com.intuit.karate.netty.FileChangedWatcher;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -60,8 +61,8 @@ public class Main implements Callable<Void> {
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
     boolean help;
 
-    @Option(names = {"-m", "--mock"}, description = "mock server file")
-    File mock;
+    @Option(names = {"-m", "--mocks"}, description = "mock server file(s)")
+    List<File> mocks;
 
     @Option(names = {"-p", "--port"}, description = "mock server port (required for --mock)")
     Integer port;
@@ -196,7 +197,7 @@ public class Main implements Callable<Void> {
         if (clean) {
             return null;
         }
-        if (mock == null) {
+        if (CollectionUtils.isEmpty(mocks)) {
             CommandLine.usage(this, System.err);
             return null;
         }
@@ -211,10 +212,10 @@ public class Main implements Callable<Void> {
             cert = new File(FeatureServer.DEFAULT_CERT_NAME);
             key = new File(FeatureServer.DEFAULT_KEY_NAME);
         }
-        FeatureServer server = FeatureServer.start(mock, port, ssl, cert, key, null);
+        FeatureServer server = FeatureServer.start(mocks, port, ssl, cert, key, null);
         if (watch) {
-            logger.info("--watch enabled, will hot-reload: {}", mock.getName());
-            FileChangedWatcher watcher = new FileChangedWatcher(mock, server, port, ssl, cert, key);
+            logger.info("--watch enabled, will hot-reload: {}", mocks.stream().map((f) -> f.getName()).collect(Collectors.toList()));
+            FileChangedWatcher watcher = new FileChangedWatcher(mocks, server, port, ssl, cert, key);
             watcher.watch();
         }
         server.waitSync();


### PR DESCRIPTION
Load Multiple Features for Karate Mocks #874

Consists of 3 changes:
- Allowing multiple feature mock files to be used for server
- Scenario precedence based on
   1. Path ([JAX-RS Path Precedence](https://www.oreilly.com/library/view/restful-java-with/9780596809300/ch04.html#I_indexterm4_d1e3224))
   2. Method
   3. Headers (Accept, Content-Type and any other)
   4. First match
   5. Default
- Path parameter regex usage in form of `{paramName:regex}`

`FeaturesBackend` has been added that asks each `FeatureBackend` for matching and default scenarios, and picks the one with the highest match score (based on rules above)

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #874
- Relevant PRs : https://github.com/intuit/karate/projects/3#card-25586564
- Type of change :
  - [x] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

