### PR TITLE
commented unused window call in webdriver

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -44,7 +44,7 @@ public abstract class WebDriver implements Driver {
     protected final Command command;
     protected final Http http;
     private final String sessionId;
-    private final String windowId;
+    //private final String windowId;
 
     protected boolean open = true;
 
@@ -67,8 +67,8 @@ public abstract class WebDriver implements Driver {
         sessionId = response.jsonPath("get[0] response..sessionId").asString();
         logger.debug("init session id: {}", sessionId);
         http.url("/session/" + sessionId);
-        windowId = http.path("window").get().jsonPath("$.value").asString();
-        logger.debug("init window id: {}", windowId);
+        //windowId = http.path("window").get().jsonPath("$.value").asString();
+        //logger.debug("init window id: {}", windowId);
         if (options.start) {
             activate();
         }


### PR DESCRIPTION
commented get `window` call from `WebDriver` as it is not used.

should be faster removing one unused call to driver and avoid hampering with the mobile driver's initialization.

- Relevant Issues : https://github.com/intuit/karate/issues/1135
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [X] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
