### PR TITLE
Changes on Appium driver to support latest Appium versions

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -494,7 +494,7 @@ public abstract class WebDriver implements Driver {
                 return http.path("element", id, "screenshot").get().jsonPath("$.value").asString();
             });
         }
-        byte[] bytes = Base64.getDecoder().decode(temp);
+        byte[] bytes = getDecoder().decode(temp);
         if (embed) {
             options.embedPngImage(bytes);
         }
@@ -557,6 +557,10 @@ public abstract class WebDriver implements Driver {
             }
             return null;
         });
+    }
+
+    protected Base64.Decoder getDecoder(){
+        return Base64.getDecoder();
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
@@ -139,4 +139,15 @@ public abstract class AppiumDriver extends WebDriver {
         return http.path("element", id, "text").get().jsonPath("$.value").asString();
     }
 
+    @Override
+    protected Base64.Decoder getDecoder(){
+        return Base64.getMimeDecoder();
+    }
+
+    @Override
+    public void close() {
+        // TODO
+    }
+
+
 }


### PR DESCRIPTION
seems like Appium doesn't respond to `window` endpoints calls for native applications. so we have to restrict all default calls to those endpoints when it is from Appium Driver.

1. changed Base64 decoder type for Appium as it sends MIME Base64 string for screenshots
2. restricted `close` function to call deletion of the `window` for Appium driver

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
