### PR TITLE
pick up stderr even when no stdout generated

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/shell/Command.java
+++ b/karate-core/src/main/java/com/intuit/karate/shell/Command.java
@@ -340,6 +340,19 @@ public class Command extends Thread {
                     listener.accept(outLine);
                 }
             }
+            if (errReader != null) { // to ensure err is collected even when no stdout
+                String errLine = errReader.readLine();
+                if (errLine != null) {
+                    logger.debug("[syserr] {}", outLine);
+                    errorBuffer.append(errLine);
+                    if (useLineFeed) {
+                        errorBuffer.append('\n');
+                    }
+                    if (errorListener != null) {
+                        errorListener.accept(errLine);
+                    }
+                }
+            }
             exitCode = process.waitFor();
             if (!sharedAppender) {
                 appender.close();


### PR DESCRIPTION
### Description

#1196 did not fully fix the issue. stderr was empty when no stdout.

This pr solves it by checking there are nothing left in stderr after stdout have been emptied.
Should work even when merging as stderr are emptied first if stdout present.

- Relevant Issues : #1191 and #1195
- Relevant PRs : #1196
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation