### PR TITLE
Changes to support appium mobile commands with input args

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -145,8 +145,8 @@ public abstract class WebDriver implements Driver {
         return DriverElement.locatorExists(this, locator);
     }
 
-    private ScriptValue eval(String expression) {
-        Json json = new Json().set("script", expression).set("args", "[]");
+    protected ScriptValue eval(String expression, Object args) {
+        Json json = new Json().set("script", expression).set("args", (args == null) ? "[]" : args);
         Http.Response res = http.path("execute", "sync").post(json);
         if (isJavaScriptError(res)) {
             logger.warn("javascript failed, will retry once: {}", res.body().asString());
@@ -159,6 +159,10 @@ public abstract class WebDriver implements Driver {
             }
         }
         return res.jsonPath("$.value").value();
+    }
+
+    protected ScriptValue eval(String expression) {
+        return eval(expression, (Map[]) null);
     }
 
     protected String getElementKey() {

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
@@ -24,6 +24,7 @@
 package com.intuit.karate.driver.appium;
 
 import com.intuit.karate.*;
+import com.intuit.karate.core.AutoDef;
 import com.intuit.karate.core.Embed;
 import com.intuit.karate.driver.DriverElement;
 import com.intuit.karate.driver.DriverOptions;
@@ -35,14 +36,22 @@ import java.io.FileOutputStream;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * @author babusekaran
  */
 public abstract class AppiumDriver extends WebDriver {
 
+    private boolean isBrowserSession;
+
     protected AppiumDriver(DriverOptions options) {
         super(options);
+        // flag to know if driver runs for browser on mobile
+        Map<String, Object> sessionPayload = (Map<String, Object>)options.getWebDriverSessionPayload();
+        Map<String, Object> desiredCapabilities = (Map<String, Object>)sessionPayload.get("desiredCapabilities");
+        isBrowserSession = (desiredCapabilities.get("browserName") != null) ? true : false;
     }
 
     @Override
@@ -53,6 +62,9 @@ public abstract class AppiumDriver extends WebDriver {
 
     @Override
     protected String selectorPayload(String id) {
+        if (isBrowserSession){ // use WebDriver selector strategies for mobile browser
+            return super.selectorPayload(id);
+        }
         Json json = new Json();
         if (id.startsWith("/")) {
             json.set("using", "xpath").set("value", id);
@@ -149,5 +161,22 @@ public abstract class AppiumDriver extends WebDriver {
         // TODO
     }
 
+    @Override
+    public Object script(String expression) {
+        if (isBrowserSession){ // use WebDriver script for mobile browser
+            return super.script(expression);
+        }
+        return eval(expression).getValue();
+    }
+
+    public Object script(String expression, List<Map<String, Object>> args) {
+        return eval(expression, args).getValue();
+    }
+
+    public Object script(String expression, Map<String, Object> args) {
+        List<Map<String, Object>> scriptArgs = new ArrayList<>(1);
+        scriptArgs.add(args);
+        return eval(expression, scriptArgs).getValue();
+    }
 
 }


### PR DESCRIPTION
- added 2 new overload for `script()` it now takes `map` or`list` of map as **2nd** argument (Only on `AppiumDriver` and its derived Drivers)
- added basic support (**locators** and **script**) for browser on mobile to use the Webdriver implementation itself, whenever `desiredCapabilities` has `browserName` appium creates driver session for the provided browser hence will check for it and use parent implementation itself (`WebDriver`) whenever needed.

ref: 
http://appium.io/docs/en/commands/mobile-command/

- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
