### PR TITLE
Ability to emulate any device for chrome driver

### DIFF
--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -75,6 +75,7 @@
     | <a href="#minimize"><code>minimize()</code></a>
     | <a href="#fullscreen"><code>fullscreen()</code></a>
     | <a href="#quit"><code>quit()</code></a>
+    | <a href="#emulatedevice"><code>driver.emulateDevice</code></a>
   </td>
 </tr>
 <tr>
@@ -701,6 +702,15 @@ This also works as a "getter" to get the current window dimensions.
 * def dims = driver.dimensions
 ```
 The result JSON will be in the form: `{ x: '#number', y: '#number', width: '#number', height: '#number' }`
+
+## `driver.emulateDevice`
+Emulate a device by passing the device width, height and the userAgent:
+
+Below example has the width, height and userAgent of Iphone X.
+
+```cucumber
+ And driver.emulateDevice = {width: 375, height: 812, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'}
+```
 
 ## `position()`
 Get the position and size of an element by [locator](#locators) as follows:

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -75,7 +75,6 @@
     | <a href="#minimize"><code>minimize()</code></a>
     | <a href="#fullscreen"><code>fullscreen()</code></a>
     | <a href="#quit"><code>quit()</code></a>
-    | <a href="#emulatedevice"><code>driver.emulateDevice</code></a>
   </td>
 </tr>
 <tr>
@@ -155,6 +154,7 @@
     | <a href="#driverscreenshotfull"><code>driver.screenshotFull()</code></a>
     | <a href="#driverintercept"><code>driver.intercept()</code></a>
     | <a href="#driverinputfile"><code>driver.inputFile()</code></a>
+    | <a href="#emulatedevice"><code>driver.emulateDevice()</code></a> 
   </td> 
 </tr>
 <tr>
@@ -702,15 +702,6 @@ This also works as a "getter" to get the current window dimensions.
 * def dims = driver.dimensions
 ```
 The result JSON will be in the form: `{ x: '#number', y: '#number', width: '#number', height: '#number' }`
-
-## `driver.emulateDevice`
-Emulate a device by passing the device width, height and the userAgent:
-
-Below example has the width, height and userAgent of Iphone X.
-
-```cucumber
- And driver.emulateDevice = {width: 375, height: 812, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'}
-```
 
 ## `position()`
 Get the position and size of an element by [locator](#locators) as follows:
@@ -1700,6 +1691,16 @@ File-upload is supported natively only by type: `chrome`. You need to call a met
 ```
 
 The `driver.inputFile()` can take an array or varargs as the second argument. Note how Karate is able to resolve a [relative path](https://github.com/intuit/karate#reading-files) to an actual OS file-path behind the scenes. If you want to point to a real file, use the `file:` prefix.
+
+## `driver.emulateDevice`
+Emulating a device is supported natively only by type: `chrome`. You need to call a method on the `driver` object directly:
+
+Below example has the width, height and userAgent of Iphone X.
+
+```cucumber
+  And driver.emulateDevice(375, 812, 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1')
+```
+
 
 ## Using `multipart file`
 This is the recommended, browser-agnostic approach that uses Karate's core-competency as an HTTP API client i.e. [`multipart file`](https://github.com/intuit/karate#multipart-file).

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -1692,7 +1692,7 @@ File-upload is supported natively only by type: `chrome`. You need to call a met
 
 The `driver.inputFile()` can take an array or varargs as the second argument. Note how Karate is able to resolve a [relative path](https://github.com/intuit/karate#reading-files) to an actual OS file-path behind the scenes. If you want to point to a real file, use the `file:` prefix.
 
-## `driver.emulateDevice`
+## `driver.emulateDevice()`
 Emulating a device is supported natively only by type: `chrome`. You need to call a method on the `driver` object directly:
 
 Below example has the width, height and userAgent of Iphone X.

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -112,7 +112,6 @@ public abstract class DevToolsDriver implements Driver {
             receive(dtm);
         });
         client = new WebSocketClient(wsOptions, logger);
-        setEmulateDeviceInternal(options.emulateDevice);
     }
 
     public int waitSync() {
@@ -444,7 +443,6 @@ public abstract class DevToolsDriver implements Driver {
 
     }
 
-    @Override
     public void setEmulateDevice(Map<String, Object> emulateDeviceParams) {
         setEmulateDeviceInternal(emulateDeviceParams);
     }

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -393,58 +393,21 @@ public abstract class DevToolsDriver implements Driver {
     }
 
     /**
-     * This method takes the parameters needed to emulate a device.
-     *
-     * @param emulateDeviceParams
-     *        This object looks for the below keys needed to emulate a device.
-     *        By default it's configured to have width and height of a Iphone X mobile.
-     *
-     *        userAgent : It's needed to be passed in every request emulating the device agent
-     *        width : Width of the device emulating.
-     *        height : Height of the device emulating.
-     *
+     * @param width of the device emulating.
+     * @param height of the device emulating.
+     * @param userAgent to be passed in every request emulating the device agent
      */
-    private void setEmulateDeviceInternal(Map<String, Object> emulateDeviceParams) {
-        if(emulateDeviceParams != null && !emulateDeviceParams.isEmpty()) {
-            if(emulateDeviceParams.containsKey("userAgent")) {
-                String userAgent = (String) emulateDeviceParams.get("userAgent");
-                logger.info("Setting userAgent={}", userAgent);
-                method("Network.setUserAgentOverride").param("userAgent", userAgent).send();
-            }
+    public void emulateDevice(Integer width, Integer height, String userAgent) {
 
-            // Defaulting to Iphone x settings
-            Integer width = 375;
-            Integer height = 812;
-            Integer deviceScaleFactor = 1;
+        logger.info("Setting deviceMetrics width={}, height={}, userAgent={}", width, height, userAgent);
+        method("Network.setUserAgentOverride").param("userAgent", userAgent).send();
+        method("Emulation.setDeviceMetricsOverride")
+                .param("width", width)
+                .param("height", height)
+                .param("deviceScaleFactor", 1)
+                .param("mobile", true)
+                .send();
 
-            Object widthObj = emulateDeviceParams.get("width");
-            if(widthObj != null) {
-                width = (Integer) widthObj;
-            }
-
-            Object heightObj = emulateDeviceParams.get("height");
-            if(heightObj != null) {
-                height = (Integer) heightObj;
-            }
-
-            Object deviceScaleFactorObj = emulateDeviceParams.get("deviceScaleFactor");
-            if(deviceScaleFactorObj != null) {
-                deviceScaleFactor = (Integer) deviceScaleFactorObj;
-            }
-
-            logger.info("Setting deviceMetrics width={}, height={}, deviceScaleFactor={}", width, height, deviceScaleFactor);
-            method("Emulation.setDeviceMetricsOverride")
-                    .param("width", width)
-                    .param("height", height)
-                    .param("deviceScaleFactor", deviceScaleFactor)
-                    .param("mobile", true)
-                    .send();
-        }
-
-    }
-
-    public void setEmulateDevice(Map<String, Object> emulateDeviceParams) {
-        setEmulateDeviceInternal(emulateDeviceParams);
     }
 
     @Override

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -112,6 +112,7 @@ public abstract class DevToolsDriver implements Driver {
             receive(dtm);
         });
         client = new WebSocketClient(wsOptions, logger);
+        setEmulateDeviceInternal(options.emulateDevice);
     }
 
     public int waitSync() {
@@ -390,6 +391,62 @@ public abstract class DevToolsDriver implements Driver {
         method("Browser.setWindowBounds")
                 .param("windowId", windowId)
                 .param("bounds", temp).send();
+    }
+
+    /**
+     * This method takes the parameters needed to emulate a device.
+     *
+     * @param emulateDeviceParams
+     *        This object looks for the below keys needed to emulate a device.
+     *        By default it's configured to have width and height of a Iphone X mobile.
+     *
+     *        userAgent : It's needed to be passed in every request emulating the device agent
+     *        width : Width of the device emulating.
+     *        height : Height of the device emulating.
+     *
+     */
+    private void setEmulateDeviceInternal(Map<String, Object> emulateDeviceParams) {
+        if(emulateDeviceParams != null && !emulateDeviceParams.isEmpty()) {
+            if(emulateDeviceParams.containsKey("userAgent")) {
+                String userAgent = (String) emulateDeviceParams.get("userAgent");
+                logger.info("Setting userAgent={}", userAgent);
+                method("Network.setUserAgentOverride").param("userAgent", userAgent).send();
+            }
+
+            // Defaulting to Iphone x settings
+            Integer width = 375;
+            Integer height = 812;
+            Integer deviceScaleFactor = 1;
+
+            Object widthObj = emulateDeviceParams.get("width");
+            if(widthObj != null) {
+                width = (Integer) widthObj;
+            }
+
+            Object heightObj = emulateDeviceParams.get("height");
+            if(heightObj != null) {
+                height = (Integer) heightObj;
+            }
+
+            Object deviceScaleFactorObj = emulateDeviceParams.get("deviceScaleFactor");
+            if(deviceScaleFactorObj != null) {
+                deviceScaleFactor = (Integer) deviceScaleFactorObj;
+            }
+
+            logger.info("Setting deviceMetrics width={}, height={}, deviceScaleFactor={}", width, height, deviceScaleFactor);
+            method("Emulation.setDeviceMetricsOverride")
+                    .param("width", width)
+                    .param("height", height)
+                    .param("deviceScaleFactor", deviceScaleFactor)
+                    .param("mobile", true)
+                    .send();
+        }
+
+    }
+
+    @Override
+    public void setEmulateDevice(Map<String, Object> emulateDeviceParams) {
+        setEmulateDeviceInternal(emulateDeviceParams);
     }
 
     @Override

--- a/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
@@ -90,6 +90,8 @@ public interface Driver extends Plugin {
 
     void setDimensions(Map<String, Object> map); // setter
 
+    void setEmulateDevice(Map<String, Object> emulateDeviceParams);
+
     String getTitle(); // getter
 
     List<String> getPages(); // getter

--- a/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
@@ -90,8 +90,6 @@ public interface Driver extends Plugin {
 
     void setDimensions(Map<String, Object> map); // setter
 
-    void setEmulateDevice(Map<String, Object> emulateDeviceParams);
-
     String getTitle(); // getter
 
     List<String> getPages(); // getter

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -97,7 +97,7 @@ public class DriverOptions {
     public final boolean highlight;
     public final int highlightDuration;
     public final String attach;
-   
+
     // mutable during a test
     private boolean retryEnabled;
     private Integer retryInterval = null;

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -97,8 +97,7 @@ public class DriverOptions {
     public final boolean highlight;
     public final int highlightDuration;
     public final String attach;
-    public Map<String, Object> emulateDevice;
-
+   
     // mutable during a test
     private boolean retryEnabled;
     private Integer retryInterval = null;

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -97,6 +97,7 @@ public class DriverOptions {
     public final boolean highlight;
     public final int highlightDuration;
     public final String attach;
+    public Map<String, Object> emulateDevice;
 
     // mutable during a test
     private boolean retryEnabled;
@@ -185,6 +186,9 @@ public class DriverOptions {
         highlight = get("highlight", false);
         highlightDuration = get("highlightDuration", Config.DEFAULT_HIGHLIGHT_DURATION);
         attach = get("attach", null);
+        emulateDevice = get("emulateDevice", new HashMap<String, Object>());
+        logger.info("emulateDevice={}", emulateDevice);
+
         // do this last to ensure things like logger, start-flag, webDriverUrl etc. are set
         port = resolvePort(defaultPort);
     }

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -186,8 +186,6 @@ public class DriverOptions {
         highlight = get("highlight", false);
         highlightDuration = get("highlightDuration", Config.DEFAULT_HIGHLIGHT_DURATION);
         attach = get("attach", null);
-        emulateDevice = get("emulateDevice", new HashMap<String, Object>());
-        logger.info("emulateDevice={}", emulateDevice);
 
         // do this last to ensure things like logger, start-flag, webDriverUrl etc. are set
         port = resolvePort(defaultPort);

--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -574,8 +574,4 @@ public abstract class WebDriver implements Driver {
     protected Base64.Decoder getDecoder(){
         return Base64.getDecoder();
     }
-
-    public void setEmulateDevice(Map<String, Object> emulateDeviceParams) {
-        logger.info("Not implemented yet !!!");
-    }
 }

--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -575,4 +575,7 @@ public abstract class WebDriver implements Driver {
         return Base64.getDecoder();
     }
 
+    public void setEmulateDevice(Map<String, Object> emulateDeviceParams) {
+        logger.info("Not implemented yet !!!");
+    }
 }


### PR DESCRIPTION
### Description

This PR contains code that will provide chrome driver the ability to emulate any device by passing the necessary parameters while configuring the driver or as a step in a scenario.

configure driver = {type: 'chrome', showDriverLog: false, **emulateDevice: {width: 375, height: 812, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'}** }

(or)

And driver.emulateDevice = { width: 375, height: 812, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1' }

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
