### PR TITLE
Fix for issue #1225 (error printing in memory JVM classes) and additi…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import net.minidev.json.JSONArray;
 import net.minidev.json.JSONStyle;
 import net.minidev.json.JSONValue;
 import net.minidev.json.parser.JSONParser;
@@ -233,6 +234,27 @@ public class JsonUtils {
 
     public static String escapeValue(String raw) {
         return JSONValue.escape(raw, JSONStyle.LT_COMPRESS);
+    }
+
+    public static Object nashornObjectToJavaJSON(Object jsObj) {
+        if (jsObj instanceof ScriptObjectMirror) {
+            ScriptObjectMirror jsObjectMirror = (ScriptObjectMirror) jsObj;
+            if (jsObjectMirror.isArray()) {
+                List list = new JSONArray();
+                for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
+                    list.add(nashornObjectToJavaJSON(entry.getValue()));
+                }
+                return list;
+            } else {
+                Map<String, Object> map = new LinkedHashMap<>();
+                for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
+                    map.put(entry.getKey(), nashornObjectToJavaJSON(entry.getValue()));
+                }
+                return map;
+            }
+        } else {
+            return jsObj;
+        }
     }
 
     public static void removeKeysWithNullValues(Object o) {

--- a/karate-core/src/main/java/com/intuit/karate/ScriptValue.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptValue.java
@@ -23,10 +23,13 @@
  */
 package com.intuit.karate;
 
-import com.intuit.karate.core.ScenarioContext;
 import com.intuit.karate.core.Feature;
+import com.intuit.karate.core.ScenarioContext;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.w3c.dom.Node;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -34,8 +37,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
-import org.w3c.dom.Node;
 
 /**
  *
@@ -457,7 +458,8 @@ public class ScriptValue {
         if (value instanceof ScriptObjectMirror) {
             ScriptObjectMirror som = (ScriptObjectMirror) value;
             if (!som.isFunction()) {
-                value = JsonUtils.toJsonDoc(value).read("$"); // results in Map or List
+                Object o = JsonUtils.nashornObjectToJavaJSON(value);
+                value = JsonPath.parse(o).read("$"); // results in Map or List
                 if (value instanceof Map) {
                     Map map = (Map) value;
                     retainRootKeyValuesWhichAreFunctions(som, map, true);

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureResult.java
@@ -29,13 +29,13 @@ import com.intuit.karate.Results;
 import com.intuit.karate.ScriptValueMap;
 import com.intuit.karate.StringUtils;
 import com.intuit.karate.exception.KarateException;
+import com.jayway.jsonpath.JsonPath;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 /**
  *
  * @author pthomas3
@@ -172,7 +172,7 @@ public class FeatureResult {
         }
         try {
             Map temp = JsonUtils.removeCyclicReferences(callArg);
-            return JsonUtils.toPrettyJsonString(JsonUtils.toJsonDoc(temp));
+            return JsonUtils.toPrettyJsonString(JsonPath.parse(temp));
         } catch (Throwable t) {
             return "#error: " + t.getMessage();
         }

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureResultTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureResultTest.java
@@ -24,15 +24,14 @@
 package com.intuit.karate.core;
 
 import com.intuit.karate.FileUtils;
-import com.intuit.karate.core.Engine;
-import com.intuit.karate.core.Feature;
-import com.intuit.karate.core.FeatureParser;
-import com.intuit.karate.core.FeatureResult;
+import net.minidev.json.JSONArray;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
+import java.util.function.IntBinaryOperator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -96,5 +95,25 @@ public class FeatureResultTest {
         // noskip should have both steps as passed
         assertTrue(contents.contains("Then assert a != 3 ........................................................ passed"));
         assertTrue(contents.contains("And assert a != 4 ......................................................... passed"));
+    }
+
+    /**
+     * Function used on testLambdaFunctionsInScenarioFeature() unit test to demonstrate the inclusion
+     * of a functional interface via the Java interloop called from the .feature file
+     * @param map
+     */
+    public static void addLambdaFunctionToMap(Map<String, Object> map) {
+        IntBinaryOperator plusOperation = (a, b) -> a + b;
+        map.put("javaSum", plusOperation);
+    }
+
+    @Test
+    public void testLambdaFunctionsInScenarioFeature() throws Exception {
+        FeatureResult result = result("caller-with-lambda-arg.feature");
+        assertEquals(0, result.getFailedCount());
+
+        JSONArray dataArr = (JSONArray) result.getResultAsPrimitiveMap().get("data");
+        assertTrue( ((Map) dataArr.get(0)).get("javaSum") instanceof IntBinaryOperator);
+        System.out.println();
     }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/caller-with-lambda-arg.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/caller-with-lambda-arg.feature
@@ -1,0 +1,44 @@
+@ignore
+Feature:
+
+Background:
+  * def dataFunc =
+  """
+    function() {
+      var element = {
+        "something": "value"
+      };
+
+      var intBinaryOperator = Java.type('java.util.function.IntBinaryOperator');
+      var plusOperation = Java.extend(intBinaryOperator, {
+          applyAsInt: function(left, right) {
+              return left + right;
+          }
+      });
+
+      var featureResultTestClass = Java.type('com.intuit.karate.core.FeatureResultTest');
+      featureResultTestClass.addLambdaFunctionToMap(element);
+      element.sum = new plusOperation();
+
+      return element;
+    }
+  """
+  * def elem = dataFunc()
+  * def data = [ "#(elem)" ]
+
+Scenario:
+  # ensuring the called.feature returns success
+  # passing data with a functional interface should be correctly printed
+  # in Result obj
+  * def input = 3
+  * def result = call read('called.feature') data
+  * match data[0].something == "value"
+  * match data[0].javaSum(1,3) == 4
+  * match data[0].sum(1,3) == 4
+
+  * def left = 1
+  * def right = 2
+  * def payload = { "leftSide": #(left), "rightSide": #(right), "sum": '#(data[0].sum(left, right))' }
+  * match payload == { "leftSide": 1, "rightSide": 2, "sum": '#? _ == 1+2' }
+  * match payload == { "leftSide": 1, "rightSide": 2, "sum": '#? _ == data[0].sum( $.leftSide, $.rightSide)' }
+


### PR DESCRIPTION
Fixing the issue reported on #1225. It's also reproducible using functional interfaces (seems like it's when in-memory JVM classes are used the minidev-json code always tries to instantiate and fails to do so). Also did a minor tweak to be able to pass these classes around and seems like it works using those functions in the Karate DSL.

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
