### PR TITLE
Fixed a issue with messages getting missed by wait.send method.

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -94,7 +94,7 @@ public abstract class DevToolsDriver implements Driver {
         logger = options.driverLogger;
         this.options = options;
         this.command = command;
-        this.wait = new DevToolsWait(options);
+        this.wait = new DevToolsWait(this, options);
         int pos = webSocketUrl.lastIndexOf('/');
         rootFrameId = webSocketUrl.substring(pos + 1);
         logger.debug("root frame id: {}", rootFrameId);
@@ -150,12 +150,12 @@ public abstract class DevToolsDriver implements Driver {
     }
     
     public DevToolsMessage sendAndWait(DevToolsMessage dtm, Predicate<DevToolsMessage> condition) {
-        send(dtm);
         boolean wasSubmit = submit;
         if (condition == null && submit) {
             submit = false;
             condition = DevToolsWait.ALL_FRAMES_LOADED;
         }
+        //Do stuff inside wait to avoid missing messages
         DevToolsMessage result = wait.send(dtm, condition);
         if (result == null && !wasSubmit) {
             throw new RuntimeException("failed to get reply for: " + dtm);

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsWait.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsWait.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 public class DevToolsWait {
 
     private final DriverOptions options;
+    private final DevToolsDriver driver;
 
     private DevToolsMessage lastSent;
     private Predicate<DevToolsMessage> condition;
@@ -73,7 +74,8 @@ public class DevToolsWait {
         return m -> name.equals(m.getMethod());
     }
 
-    public DevToolsWait(DriverOptions options) {
+    public DevToolsWait(DevToolsDriver driver, DriverOptions options) {
+        this.driver = driver;
         this.options = options;
         logger = options.driverLogger;
     }
@@ -97,6 +99,7 @@ public class DevToolsWait {
         synchronized (this) {
             logger.trace(">> wait: {}", dtm);
             try {
+                driver.send(dtm);
                 wait(timeout);
             } catch (InterruptedException e) {
                 logger.error("interrupted: {} wait: {}", e.getMessage(), dtm);


### PR DESCRIPTION
The 🐞 cause was lastSent getting set late then reponse come out from websocket.

### Description

- Relevant Issues : Random timeout while waiting messages back from websocket
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation