### PR TITLE
implemented https://w3c.github.io/webdriver/#print currently supporte…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -800,6 +800,7 @@ public abstract class DevToolsDriver implements Driver {
         return currentDialogText;
     }
 
+    @Override
     public byte[] pdf(Map<String, Object> options) {
         DevToolsMessage dtm = method("Page.printToPDF").params(options).send();
         String temp = dtm.getResult("data").getAsString();

--- a/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/Driver.java
@@ -436,6 +436,9 @@ public interface Driver extends Plugin {
         return after;
     }
 
+    @AutoDef
+    public byte[] pdf(Map<String, Object> options);
+
     // for internal use ========================================================
     //        
     boolean isTerminated();

--- a/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/WebDriver.java
@@ -588,4 +588,11 @@ public abstract class WebDriver implements Driver {
     protected Base64.Decoder getDecoder() {
         return Base64.getDecoder();
     }
+
+    @Override
+    public byte[] pdf(Map<String, Object> printOptions){
+        String temp = http.path("print").post(printOptions).jsonPath("$.value").asString();
+        return Base64.getDecoder().decode(temp);
+    }
+
 }


### PR DESCRIPTION
Implemented https://w3c.github.io/webdriver/#print as `pdf()`, streamlined `pdf()` API between `DevToolsDriver` and `WebDriver`.

```
pdf({})
```

currently supported in **chrome > 85** with **chromedriver > 85** and only in **headless** mode

sample input json to `pdf()` supported as per w3c spec


```
 {
      'orientation': 'landscape',
      'scale': 1.1,
      'margin': {
        'top': 1.1,
        'bottom': 2.2,
        'left': 3.3,
        'right': 4.4
       },
      'background': true,
      'shrinkToFit': false,
      'pageRanges': [1],
      'page': {
       'width': 15.6,
       'height': 20.6
     }
 }
```

ref:
https://chromedriver.storage.googleapis.com/85.0.4183.83/notes.txt
https://bugs.chromium.org/p/chromedriver/issues/detail?id=3481&q=3481&can=2
https://w3c.github.io/webdriver/#print

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
