### PR TITLE
Issue-1181 ApacheHttpClient custom content type quotes issue fix

### DIFF
--- a/karate-apache/pom.xml
+++ b/karate-apache/pom.xml
@@ -47,6 +47,13 @@
             <version>1.7.25</version>
             <scope>runtime</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency> 
 
     </dependencies>          
     

--- a/karate-apache/src/test/java/com/intuit/karate/http/apache/ApacheHttpUtilsTest.java
+++ b/karate-apache/src/test/java/com/intuit/karate/http/apache/ApacheHttpUtilsTest.java
@@ -1,0 +1,41 @@
+package com.intuit.karate.http.apache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpEntity;
+import org.junit.Test;
+
+/** @author nsehgal */
+public class ApacheHttpUtilsTest {
+
+  @Test
+  public void testContentTypeWithQuotes() {
+    final String originalContentType =
+        "multipart/related; charset=UTF-8; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+
+    assertEquals(originalContentType, httpEntity.getContentType().getValue());
+  }
+
+  @Test
+  public void testContentTypeWithoutQuotes() {
+    final String originalContentType =
+        "multipart/related; charset=UTF-8; boundary=----=_Part_19_1913847857.1592612068756; type=application/xop+xml; start-info=text/xml";
+
+    final String expectedContentType =
+        "multipart/related; charset=UTF-8; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+ 
+    assertNotEquals(originalContentType, httpEntity.getContentType().getValue());
+    assertEquals(expectedContentType, httpEntity.getContentType().getValue());
+  }
+}

--- a/karate-core/src/main/java/com/intuit/karate/StringUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/StringUtils.java
@@ -222,4 +222,27 @@ public class StringUtils {
         }
     }
 
+  /**
+   * Removes the single occurrence of double quote from the start and end of the supplied string.
+   *
+   * <p>A {@code null} input String returns {@code null}.
+   *
+   * <pre>
+   * StringUtils.trimDoubleQuotes(null)           = null
+   * StringUtils.trimDoubleQuotes("")             = ""
+   * StringUtils.trimDoubleQuotes(" ")            = " "
+   * StringUtils.trimDoubleQuotes("\"foo\"")      = "foo"
+   * StringUtils.trimDoubleQuotes("\"foo")        = "foo"
+   * StringUtils.trimDoubleQuotes("\"\"foo\"\"")  = "\"foo\""
+   * </pre>
+   *
+   * @param str the String to remove quotes from, may be null
+   * @return the stripped String, {@code null} if null String input
+   */
+  public static String trimDoubleQuotes(String str) {
+    if (null == str) {
+      return str;
+    }
+    return str.replaceAll("^\"|\"$", EMPTY);
+  }
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
@@ -115,7 +115,7 @@ public class HttpUtils {
                 continue;
             }
             String key = item.substring(0, pos).trim();
-            String val = item.substring(pos + 1).trim();
+            String val = StringUtils.trimDoubleQuotes(item.substring(pos + 1).trim());
             map.put(key, val);
         }
         return map;

--- a/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
@@ -157,4 +157,15 @@ public class StringUtilsTest {
                 StringUtils.wrappedLinesEstimate("", 2));
     }
     
+    @Test
+    public void testTrimDoubleQuotes() {
+        assertEquals("foo", StringUtils.trimDoubleQuotes("\"foo\""));
+        assertEquals("", StringUtils.trimDoubleQuotes(""));
+        assertEquals(" ", StringUtils.trimDoubleQuotes(" "));
+        assertEquals(null, StringUtils.trimDoubleQuotes(null));
+        assertEquals(" ", StringUtils.trimDoubleQuotes(" "));
+        assertEquals("foo", StringUtils.trimDoubleQuotes("\"foo"));
+        assertEquals("\"foo\"", StringUtils.trimDoubleQuotes("\"\"foo\"\""));
+        assertEquals("foo", StringUtils.trimDoubleQuotes("foo\""));
+    }
 }


### PR DESCRIPTION
### Description

Manually constructed content-type headers with quotes are not processed correctly 
While using ApacheHttpClient and passing custom media type in getEntity(..) method quotes are getting escaped.

- Relevant Issues : https://github.com/intuit/karate/issues/1181
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
