### PR TITLE
Issue-1181 ApacheHttpClient custom content type quotes issue fix

### DIFF
--- a/karate-apache/pom.xml
+++ b/karate-apache/pom.xml
@@ -47,6 +47,13 @@
             <version>1.7.25</version>
             <scope>runtime</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency> 
 
     </dependencies>          
     

--- a/karate-apache/src/test/java/com/intuit/karate/http/apache/ApacheHttpUtilsTest.java
+++ b/karate-apache/src/test/java/com/intuit/karate/http/apache/ApacheHttpUtilsTest.java
@@ -1,0 +1,73 @@
+package com.intuit.karate.http.apache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpEntity;
+import org.junit.Test;
+
+/** @author nsehgal */
+public class ApacheHttpUtilsTest {
+
+  @Test
+  public void testContentTypeWithQuotes() {
+    final String originalContentType =
+        "multipart/related; charset=UTF-8; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+
+    assertEquals(originalContentType, httpEntity.getContentType().getValue());
+  }
+
+  @Test
+  public void testContentTypeWithoutQuotes() {
+    final String originalContentType =
+        "multipart/related; charset=UTF-8; boundary=----=_Part_19_1913847857.1592612068756; type=application/xop+xml; start-info=text/xml";
+
+    final String expectedContentType =
+        "multipart/related; charset=UTF-8; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+ 
+    assertNotEquals(originalContentType, httpEntity.getContentType().getValue());
+    assertEquals(expectedContentType, httpEntity.getContentType().getValue());
+  }
+
+  @Test
+  public void testContentTypeWithoutQuotesCharsetInLast() {
+    final String originalContentType =
+        "multipart/related; boundary=----=_Part_19_1913847857.1592612068756; type=application/xop+xml; start-info=text/xml; charset=UTF-8";
+
+    final String expectedContentType =
+        "multipart/related; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"; charset=UTF-8";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+
+    assertNotEquals(originalContentType, httpEntity.getContentType().getValue());
+    assertEquals(expectedContentType, httpEntity.getContentType().getValue());
+  }
+
+  @Test
+  public void testContentTypeWithCustomCharset() {
+    final String originalContentType =
+        "multipart/related; boundary=----=_Part_19_1913847857.1592612068756; type=application/xop+xml; start-info=text/xml";
+
+    final String expectedContentType =
+        "multipart/related; boundary=\"----=_Part_19_1913847857.1592612068756\"; type=\"application/xop+xml\"; start-info=\"text/xml\"; charset=UTF-8";
+
+    HttpEntity httpEntity =
+        ApacheHttpUtils.getEntity(
+            "content is not important", originalContentType, StandardCharsets.UTF_8);
+
+    assertNotEquals(originalContentType, httpEntity.getContentType().getValue());
+    assertEquals(expectedContentType, httpEntity.getContentType().getValue());
+  }
+}


### PR DESCRIPTION
### Description

Manually constructed content-type headers with quotes are not processed correctly
While using ApacheHttpClient and passing custom media type in getEntity(..) method quotes are getting escaped.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
