### PR TITLE
Use Spring Boot 2.3.4 for Demo project

### DIFF
--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -35,12 +35,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring.boot.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
             <version>${spring.version}</version>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -113,7 +118,12 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>${jaxb.version}</version>
-        </dependency>                                                                             		
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/config/ServerStartedInitializingBean.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
  * @author pthomas3
  */
 @Component
-public class ServerStartedInitializingBean implements ApplicationRunner, ApplicationListener<EmbeddedServletContainerInitializedEvent> {
+public class ServerStartedInitializingBean implements ApplicationRunner, ApplicationListener<WebServerInitializedEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(ServerStartedInitializingBean.class);
 
@@ -53,9 +53,8 @@ public class ServerStartedInitializingBean implements ApplicationRunner, Applica
     }
 
     @Override
-    public void onApplicationEvent(EmbeddedServletContainerInitializedEvent e) {
-        localPort = e.getEmbeddedServletContainer().getPort();
+    public void onApplicationEvent(WebServerInitializedEvent event) {
+        localPort = event.getWebServer().getPort();
         logger.info("after runtime init, local server port: {}", localPort);
     }
-
 }

--- a/karate-demo/src/main/java/com/intuit/karate/demo/config/TomcatConfig.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/config/TomcatConfig.java
@@ -23,38 +23,24 @@
  */
 package com.intuit.karate.demo.config;
 
-import org.apache.catalina.Context;
 import org.apache.tomcat.util.http.LegacyCookieProcessor;
-import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- *
  * @author pthomas3
  */
 @Configuration
 public class TomcatConfig {
 
     @Bean
-    public EmbeddedServletContainerCustomizer cookieProcessorCustomizer() {
-        return new EmbeddedServletContainerCustomizer() {
-            @Override
-            public void customize(ConfigurableEmbeddedServletContainer container) {
-                if (container instanceof TomcatEmbeddedServletContainerFactory) {
-                    TomcatEmbeddedServletContainerFactory factory = (TomcatEmbeddedServletContainerFactory) container;
-                    factory.addContextCustomizers(new TomcatContextCustomizer() {
-                        @Override
-                        public void customize(Context context) {
-                            context.setCookieProcessor(new LegacyCookieProcessor());
-                        }
-                    });
-                }
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> cookieProcessorCustomizer() {
+        return factory -> {
+            if (factory != null) {
+                factory.addContextCustomizers(context -> context.setCookieProcessor(new LegacyCookieProcessor()));
             }
-
         };
     }
 

--- a/karate-demo/src/main/resources/application.properties
+++ b/karate-demo/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 spring.jackson.default-property-inclusion=NON_NULL
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.resources.add-mappings=false
+
+spring.datasource.generate-unique-name=false

--- a/karate-demo/src/test/java/demo/error/no-url.feature
+++ b/karate-demo/src/test/java/demo/error/no-url.feature
@@ -9,7 +9,6 @@ Feature:  No URLfound proper error response
     When method get
     Then status 404
     And match header content-type contains 'application/json'
-    And match header content-type contains 'charset=UTF-8'
     And match response.status_code == 404
     And match response.method == 'GET'
     And match response.error_message == 'The URL you have reached is not in service at this time'

--- a/karate-demo/src/test/java/demo/headers/content-type.feature
+++ b/karate-demo/src/test/java/demo/headers/content-type.feature
@@ -11,11 +11,9 @@ Scenario: json post with charset
     When method post
     Then status 200    
     And match header content-type contains 'application/json'
-    And match header content-type contains 'charset=UTF-8'
     And def response = karate.lowerCase(response)
     And def temp = response['content-type'][0]
     And match temp contains 'application/json'
-    And match temp contains 'charset=utf-8'
 
 Scenario: form post with charset
     Given path 'search', 'headers'

--- a/karate-demo/src/test/java/mock/contract/PaymentService.java
+++ b/karate-demo/src/test/java/mock/contract/PaymentService.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/karate-demo/src/test/java/ssl/TestService.java
+++ b/karate-demo/src/test/java/ssl/TestService.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/karate-jersey/src/test/java/ssl/TestService.java
+++ b/karate-jersey/src/test/java/ssl/TestService.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/karate-junit4/src/test/java/com/intuit/karate/junit4/files/BootJarLoadingTest.java
+++ b/karate-junit4/src/test/java/com/intuit/karate/junit4/files/BootJarLoadingTest.java
@@ -61,7 +61,7 @@ public class BootJarLoadingTest {
         }
 
         ClassLoader createClassLoader() throws Exception {
-            return createClassLoader(getClassPathArchives());
+            return createClassLoader(getClassPathArchivesIterator());
         }
     }
 

--- a/karate-mock-servlet/src/test/java/demo/MockSpringMvcServlet.java
+++ b/karate-mock-servlet/src/test/java/demo/MockSpringMvcServlet.java
@@ -32,7 +32,7 @@ import javax.servlet.ServletContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.boot.autoconfigure.web.WebMvcProperties;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties;
 import org.springframework.mock.web.MockServletConfig;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <junit.version>4.12</junit.version>
         <javafx.controls.version>13-ea+12</javafx.controls.version>
         <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
-        <spring.version>4.3.8.RELEASE</spring.version>
-        <spring.boot.version>1.5.16.RELEASE</spring.boot.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
+        <spring.boot.version>2.3.4.RELEASE</spring.boot.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>        
         <cucumber.reporting.version>3.8.0</cucumber.reporting.version>
     </properties>


### PR DESCRIPTION
### Description

This PR is to upgrade the Spring Boot version used for the demo project.

- Relevant Issues :

As you can see, in the following files : 

`karate-demo/src/test/java/demo/error/no-url.feature`
`karate-demo/src/test/java/demo/headers/content-type.feature`

I've removed the test looking for `charset=UTF-8`, since Spring Consider this as the default value and marked his `MediaType#APPLICATION_JSON_UTF8` as deprecated ( [See here](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/MediaType.html#APPLICATION_JSON_UTF8) ). As compiler is launched with the `-Werror` flag, forcing the server to send this header, would fail the build.

- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
