### PR TITLE
Issue-1076 Updating cucumber-reporting version to 5.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <spring.version>5.2.9.RELEASE</spring.version>
         <spring.boot.version>2.3.4.RELEASE</spring.boot.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>        
-        <cucumber.reporting.version>3.8.0</cucumber.reporting.version>
+        <cucumber.reporting.version>5.3.1</cucumber.reporting.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### Description

Updated dependency for cucumber-reporting from 3.8.0 to 5.3.1.As part of this upgrade below two version has also been updated.

jackson-databind is upgraded to 2.10.1 from 2.8.5
commons-collections is upgraded to 3.2.2 from 3.2.1
lo4j-api,log4j-core are no longer pulled from cucumber-reporting.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
