### PR TITLE
#1211 Standard delete Cookie behaviour does not work in Karate

### DIFF
--- a/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
+++ b/karate-apache/src/main/java/com/intuit/karate/http/apache/ApacheHttpClient.java
@@ -334,7 +334,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
         }
         cookieStore.clear(); // we rely on the StepDefs for cookie 'persistence'
         for (Header header : httpResponse.getAllHeaders()) { // rely on setting cookies from set-cookie header, else these will be skipped.
-            if( header.getName().contains("Set-Cookie"))
+            if( header.getName().equalsIgnoreCase("Set-Cookie"))
             {
                 List<HttpCookie> cookieMap = HttpCookie.parse(header.getValue());
                 cookieMap.forEach( ck -> {
@@ -345,7 +345,7 @@ public class ApacheHttpClient extends HttpClient<HttpEntity> {
                     response.addCookie(cookie);
                 });
             }
-                response.addHeader(header.getName(), header.getValue());
+            response.addHeader(header.getName(), header.getValue());
         }
         return response;
     }

--- a/karate-demo/src/test/java/demo/cookies/cookies.feature
+++ b/karate-demo/src/test/java/demo/cookies/cookies.feature
@@ -105,3 +105,21 @@ Scenario: non-expired cookie is in response
     When method get
     Then status 200
     And match response[0] contains { name: 'foo', value: 'bar', domain: '.abc.com' }
+
+@apache @mock-servlet-todo
+Scenario: manually expire cookie by setting max-age to 0.
+    Given path 'search', 'cookies'
+    And cookie foo = {value:'bar', max-age:'0', path:'/search'}
+    And param domain = '.abc.com'
+    When method get
+    Then status 200
+    And match response == []
+
+@apache @mock-servlet-todo
+Scenario: max-age is -1, cookie should persist.
+    Given path 'search', 'cookies'
+    And cookie foo = {value:'bar', max-age:'-1', path:'/search'}
+    And param domain = '.abc.com'
+    When method get
+    Then status 200
+    And match response[0] contains { name: 'foo', value: 'bar', domain: '.abc.com' }


### PR DESCRIPTION
#1211 Standard delete Cookie behaviour does not work in Karate

We delete cookies by setting expiration from max-age. If cookie is getting expired via set-cookie header, modified code to include this while adding the cookie.

- Relevant Issues : #1211 Standard delete Cookie behaviour does not work in Karate
- Type of change :
  - [ ] Bug fix for existing feature
 
