### PR TITLE
1331 - karate-netty proxy sends previous request payload when dealing…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
@@ -108,6 +108,10 @@ public class FeaturesBackend {
                     }
                 }
                 match.def(ScriptValueMap.VAR_REQUEST, requestBody);
+            } else {
+                // fix for # 1331. If the incoming request body is empty, previous request body was getting used. This will force reset.
+                // or we should remove this from ScriptValueMap?
+                match.def(ScriptValueMap.VAR_REQUEST, null);
             }
 
             FeatureBackend.FeatureScenarioMatch matchingInfo = getMatchingScenario(match.vars());


### PR DESCRIPTION
### Description: 1331 karate-netty proxy sends previous request payload when dealing with next request fix.

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #1331 
- Relevant PRs : (optional)
- Type of change :
  - [x] Bug fix for existing feature

