### PR TITLE
Issue-1243 reverting Junit 5 Single scenario limitation from Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,6 @@ Multiple feature files (or paths) can be specified, de-limited by the space char
 ```
 mvn test "-Dkarate.options=PathToFeatureFiles/order.feature:12" -Dtest=DemoTestParallel
 ```
-Note that this is currently not supported for [JUnit 5](#junit-5)  `@Karate.Test` annotation.
 
 ### Command Line - Gradle
 


### PR DESCRIPTION

### Description
Reverting Junit 5 Single scenario limitation from Documentation as it is working as expected for Junit 5.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation
