### PR TITLE
fix: fixing complex optional schema validation issue 1321

### DIFF
--- a/karate-core2/src/main/java/com/intuit/karate/match/MatchContext.java
+++ b/karate-core2/src/main/java/com/intuit/karate/match/MatchContext.java
@@ -38,8 +38,9 @@ public class MatchContext {
     public final String path;
     public final String name;
     public final int index;
+    public final boolean schema;
 
-    protected MatchContext(JsEngine js, MatchOperation root, boolean xml, int depth, String path, String name, int index) {
+    protected MatchContext(JsEngine js, MatchOperation root, boolean xml, int depth, String path, String name, int index, boolean schema) {
         this.JS = js;
         this.root = root;
         this.xml = xml;
@@ -47,24 +48,25 @@ public class MatchContext {
         this.path = path;
         this.name = name;
         this.index = index;
+        this.schema = schema;
     }
 
     public MatchContext descend(String name) {
         if (xml) {
             String childPath = path.endsWith("/@") ? path + name : (depth == 0 ? "" : path) + "/" + name;
-            return new MatchContext(JS, root, xml, depth + 1, childPath, name, -1);
+            return new MatchContext(JS, root, xml, depth + 1, childPath, name, -1, schema);
         } else {
             boolean needsQuotes = name.indexOf('-') != -1 || name.indexOf(' ') != -1 || name.indexOf('.') != -1;
             String childPath = needsQuotes ? path + "['" + name + "']" : path + '.' + name;
-            return new MatchContext(JS, root, xml, depth + 1, childPath, name, -1);
+            return new MatchContext(JS, root, xml, depth + 1, childPath, name, -1, schema);
         }
     }
 
     public MatchContext descend(int index) {
         if (xml) {
-            return new MatchContext(JS, root, xml, depth + 1, path + "[" + (index + 1) + "]", name, index);
+            return new MatchContext(JS, root, xml, depth + 1, path + "[" + (index + 1) + "]", name, index, schema);
         } else {
-            return new MatchContext(JS, root, xml, depth + 1, path + "[" + index + "]", name, index);
+            return new MatchContext(JS, root, xml, depth + 1, path + "[" + index + "]", name, index, schema);
         }
     }
 

--- a/karate-core2/src/main/java/com/intuit/karate/match/MatchOperation.java
+++ b/karate-core2/src/main/java/com/intuit/karate/match/MatchOperation.java
@@ -72,6 +72,7 @@ public class MatchOperation {
         this.expected = expected;
 
         boolean schema = type == MatchType.EQUALS_SCHEMA;
+
         if (context == null) {
             if (js == null) {
                 js = JsEngine.global();
@@ -181,7 +182,7 @@ public class MatchOperation {
         if (expected.isString()) {
             String expStr = expected.getValue();
             if (expStr.startsWith("#")) {
-                if (type == MatchType.EQUALS || type == MatchType.EQUALS_SCHEMA) {
+                if (type == MatchType.EQUALS) {
                     return macroEqualsExpected(expStr) ? pass() : fail(null);
                 } else {
                     return macroEqualsExpected(expStr) ? fail("is equal") : pass();

--- a/karate-core2/src/main/java/com/intuit/karate/match/MatchOperation.java
+++ b/karate-core2/src/main/java/com/intuit/karate/match/MatchOperation.java
@@ -67,18 +67,20 @@ public class MatchOperation {
     }
 
     private MatchOperation(JsEngine js, MatchContext context, MatchType type, MatchValue actual, MatchValue expected) {
-        this.type = type;
+        this.type = type == MatchType.EQUALS_SCHEMA ? MatchType.EQUALS : type;
         this.actual = actual;
         this.expected = expected;
+
+        boolean schema = type == MatchType.EQUALS_SCHEMA;
         if (context == null) {
             if (js == null) {
                 js = JsEngine.global();
             }
             this.failures = new ArrayList();
             if (actual.isXml()) {
-                this.context = new MatchContext(js, this, true, 0, "/", "", -1);
+                this.context = new MatchContext(js, this, true, 0, "/", "", -1, schema);
             } else {
-                this.context = new MatchContext(js, this, false, 0, "$", "", -1);
+                this.context = new MatchContext(js, this, false, 0, "$", "", -1, schema);
             }
         } else {
             this.context = context;
@@ -179,7 +181,7 @@ public class MatchOperation {
         if (expected.isString()) {
             String expStr = expected.getValue();
             if (expStr.startsWith("#")) {
-                if (type == MatchType.EQUALS) {
+                if (type == MatchType.EQUALS || type == MatchType.EQUALS_SCHEMA) {
                     return macroEqualsExpected(expStr) ? pass() : fail(null);
                 } else {
                     return macroEqualsExpected(expStr) ? fail("is equal") : pass();
@@ -420,6 +422,10 @@ public class MatchOperation {
                         }
                         continue;
                     }
+                }
+                if(context.schema){
+                    unMatchedKeysExp.remove(key);
+                    continue;
                 }
                 if (type != MatchType.CONTAINS_ANY) {
                     return fail("actual does not contain key - '" + key + "'");

--- a/karate-core2/src/main/java/com/intuit/karate/match/MatchType.java
+++ b/karate-core2/src/main/java/com/intuit/karate/match/MatchType.java
@@ -30,6 +30,7 @@ package com.intuit.karate.match;
 public enum MatchType {
     
     EQUALS,
+    EQUALS_SCHEMA,
     NOT_EQUALS,
     CONTAINS,    
     NOT_CONTAINS,

--- a/karate-core2/src/test/java/com/intuit/karate/match/MatchTest.java
+++ b/karate-core2/src/test/java/com/intuit/karate/match/MatchTest.java
@@ -239,7 +239,6 @@ class MatchTest {
     void testXmlSchema() {
         match("<root></root>", EQUALS, "<root>#null</root>"); // TODO controversial
         match("<root></root>", EQUALS, "<root>#present</root>");
-        match("<root><a>x</a><b><c>y</c></b></root>", EQUALS, "<root><a>#string</a><b><c>#string</c></b></root>");
     }
 
     @Test

--- a/karate-core2/src/test/java/com/intuit/karate/match/MatchTest.java
+++ b/karate-core2/src/test/java/com/intuit/karate/match/MatchTest.java
@@ -239,6 +239,23 @@ class MatchTest {
     void testXmlSchema() {
         match("<root></root>", EQUALS, "<root>#null</root>"); // TODO controversial
         match("<root></root>", EQUALS, "<root>#present</root>");
+        match("<root><a>x</a><b><c>y</c></b></root>", EQUALS, "<root><a>#string</a><b><c>#string</c></b></root>");
     }
+
+    @Test
+    void testXmlEqualsSchema(){
+        match("<root><a>x</a></root>", EQUALS_SCHEMA, "<root><a>#string</a><b><c>#string</c></b></root>");
+        match("<root><a>x</a><b></b></root>", EQUALS_SCHEMA, "<root><a>#string</a><b><c>#string</c></b></root>", FAILS);
+        match("<root><a>x</a><b><c></c></b></root>", EQUALS_SCHEMA, "<root><a>#string</a><b><c>#string</c></b></root>", FAILS);
+        match("<root><a>x</a><b><c>y</c></b></root>", EQUALS_SCHEMA, "<root><a>#string</a><b><c>#string</c></b></root>");
+    }
+
+    @Test
+    void testJsonEqualsSchema(){
+        match("{ a: 'x' }", EQUALS_SCHEMA, "{ a: '#string', b: { c: '#string' }}");
+        match("{ a: 'x', b:{} }", EQUALS_SCHEMA, "{ a: '#string', b: { c: '#string' }}");
+        match("{ a: 'x', b:{ c: 'y' } }", EQUALS_SCHEMA, "{ a: '#string', b: { c: '#string' }}");
+    }
+
 
 }


### PR DESCRIPTION
### Description

Created a new `MatchType` to handle `EQUALS` operation for `SCHEMA`s. This way we can control how we want to compare expected XML or JSON schema with the actual value.


Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : 1321
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
