### PR TITLE
#1368 - Allow a Karate scenario to be able to return values to the Gatling Simulation

### DIFF
--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -83,6 +83,7 @@
                 <configuration>
                     <disableCompiler>true</disableCompiler>
                     <skip>${skipTests}</skip>
+                    <runMultipleSimulations>true</runMultipleSimulations>
                 </configuration>
                 <executions>
                     <execution>

--- a/karate-gatling/src/test/scala/mock2/CatsSimulation.scala
+++ b/karate-gatling/src/test/scala/mock2/CatsSimulation.scala
@@ -1,0 +1,60 @@
+package mock2
+
+import java.util.concurrent.ConcurrentLinkedDeque
+
+import com.intuit.karate.gatling.PreDef._
+import io.gatling.core.Predef._
+
+import scala.concurrent.duration._
+
+class CatsSimulation extends Simulation {
+
+  MockUtils.startServer()
+
+  val protocol = karateProtocol(
+    "/cats/{id}" -> Nil,
+    "/cats" ->  Nil
+  )
+
+  val nameFeeder = Array(
+    Map("name" -> "Amy"),
+    Map("name" -> "Billie"),
+    Map("name" -> "Charlie"),
+    Map("name" -> "Dot"),
+    Map("name" -> "Eve")
+  )
+  val count = nameFeeder.readRecords.length
+  val idQueue = new ConcurrentLinkedDeque[String]
+
+  val create = scenario("create")
+    .feed(nameFeeder)
+    .exec(karateFeature("classpath:mock2/cats-create.feature"))
+    .exec { session =>
+      // If the above karate feature executed successfully then there will be an "id" attribute
+      // Save this to the queue
+      if (session.contains("id")) {
+        val id = session("id").as[String]
+        idQueue.add(id)
+      }
+      session
+    }
+  val delete = scenario("delete")
+    .exec { session =>
+      // Read an id from a queue and feed it to the session
+      val id = idQueue.poll()
+      if (id != null) {
+        session.set("id", id)
+      } else {
+        session
+      }
+    }
+    // Don't continue to execute the following karate feature if the session doesn't have an id
+    .exitHereIf { session => !session.contains("id") }
+    .exec(karateFeature("classpath:mock2/cats-delete.feature"))
+
+  setUp(
+    create.inject(rampUsers(count) during (5 seconds)).protocols(protocol).andThen(
+      delete.inject(rampUsers(count) during (5 seconds)).protocols(protocol)
+    )
+  )
+}

--- a/karate-gatling/src/test/scala/mock2/MockUtils.java
+++ b/karate-gatling/src/test/scala/mock2/MockUtils.java
@@ -1,0 +1,15 @@
+package mock2;
+
+import com.intuit.karate.FileUtils;
+import com.intuit.karate.netty.FeatureServer;
+
+import java.io.File;
+
+class MockUtils {
+
+    static void startServer() {
+        File file = FileUtils.getFileRelativeTo(MockUtils.class, "mock.feature");
+        FeatureServer server = FeatureServer.start(file, 0, false, null);
+        System.setProperty("mock.cats.url", server.getBaseUrl() + "/cats");
+    }
+}

--- a/karate-gatling/src/test/scala/mock2/cats-create.feature
+++ b/karate-gatling/src/test/scala/mock2/cats-create.feature
@@ -1,0 +1,24 @@
+Feature:
+
+  Background:
+    * url karate.properties['mock.cats.url']
+
+  Scenario: create and get cat
+    * def name = __gatling.name
+    * print 'Creating cat with name ' + name
+    Given request { name: #(name) }
+    When method post
+    Then status 200
+    And match response == { id: '#uuid', name: #(name) }
+    * def id = response.id
+
+    * print 'Getting cat with id ' + id
+    Given path id
+    When method get
+    Then status 200
+    And match response == { id: '#(id)', name: #(name) }
+
+    # Save id
+    And def extra = { id: #(id) }
+    And def updated = karate.merge(__gatling, extra)
+    And karate.set('__gatling', updated)

--- a/karate-gatling/src/test/scala/mock2/cats-delete.feature
+++ b/karate-gatling/src/test/scala/mock2/cats-delete.feature
@@ -1,0 +1,16 @@
+Feature:
+
+  Background:
+    * url karate.properties['mock.cats.url']
+
+  Scenario: delete cat and verify
+    * def id = __gatling.id
+    * print 'Deleting cat with id ' + id
+    Given path id
+    When method delete
+    Then status 200
+
+    * print 'Getting cat with id ' + id
+    Given path id
+    When method get
+    Then status 404

--- a/karate-gatling/src/test/scala/mock2/mock.feature
+++ b/karate-gatling/src/test/scala/mock2/mock.feature
@@ -1,0 +1,45 @@
+Feature: cats stateful crud
+
+  Background:
+    * def uuid = function(){ return java.util.UUID.randomUUID() + '' }
+    * def cats = {}
+
+  Scenario: pathMatches('/cats') && methodIs('post')
+    * def cat = request
+    * def badRequest =
+    """
+    function() {
+      karate.set('responseStatus', 400)
+      karate.abort()
+    }
+    """
+    * if (cat.name == 'Billie') badRequest()
+    * def id = uuid()
+    * cat.id = id
+    * cats[id] = cat
+    * def response = cat
+
+  Scenario: pathMatches('/cats/{id}') && methodIs('get')
+    * def id = pathParams.id
+    * def notFound =
+    """
+    function() {
+      karate.set('responseStatus', 404)
+      karate.abort()
+    }
+    """
+    * def cat = cats[id]
+    * if (cat == null) notFound()
+    * def response = cat
+
+  Scenario: pathMatches('/cats/{id}') && methodIs('delete')
+    * def id = pathParams.id
+    * def notFound =
+    """
+    function() {
+      karate.set('responseStatus', 404)
+      karate.abort()
+    }
+    """
+    * if (cats[id] == null) notFound()
+    * karate.remove('cats', '$.' + id)


### PR DESCRIPTION
PR for issue #1368 

Within a Karate feature, changes can be made to the __gatling object and these will be read and accessible in the Gatling simulation.

To test this, a new example has been added whereby we want to create n cats with different names, and then delete all successfully created cats.

- In the simulation declare a feeder containing n names
- Run the create scenario (create a cat and verify it exists) n times using this feeder - if the scenario is successful then at the end the id will be saved
- Back in the simulation, we can read the id (present only if the scenario was successful) and add to a queue
- Run the delete scenario (delete a cat and verify it no longer exists) n times - each time it will get the next id from the queue

This test demonstrates the case where one of the create steps fails (so this scenario exits early and doesn't "return" an id), and therefore one of the delete scenarios is not executed.
E.g. run in karate-gatling
```
mvn clean test
```
4/5 cats are created successfully, so only 8 (2x4) GET calls and 4 DELETE calls
```
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=16     KO=1     )
> POST /cats                                               (OK=4      KO=1     )
> GET /cats/{id}                                           (OK=8      KO=0     )
> DELETE /cats/{id}                                        (OK=4      KO=0     )
---- Errors --------------------------------------------------------------------
> classpath:mock2/cats-create.feature:11 status 200                   1 (100.0%)
```

This PR is not yet complete as there are some warnings
```
[WARNING] /Users/theathlete3141/Karate-theathlete3141/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateAction.scala:52: warning: non-variable type argument String in type pattern collection.convert.Wrappers.MapWrapper[String,Any] is unchecked since it is eliminated by erasure
[WARNING]               case mapWrapper: scala.collection.convert.Wrappers.MapWrapper[String, Any] =>
[WARNING]                                                                  ^
[WARNING] /Users/theathlete3141/Karate-theathlete3141/karate-gatling/src/main/scala/com/intuit/karate/gatling/KarateAction.scala:54: warning: non-variable type argument String in type pattern java.util.Map[String,Any] is unchecked since it is eliminated by erasure
[WARNING]               case javaMap: util.Map[String, Any] =>
[WARNING]                                  ^
[WARNING] two warnings found
```
I wasn't very happy with this part of the code anyway so any help here would be appreciated.