### PR TITLE
fixes removal of "drive letter" in windows path that didn't work for vscode debuger

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/resource/ResourceUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/resource/ResourceUtils.java
@@ -226,8 +226,7 @@ public class ResourceUtils {
     }
 
     private static String removePrefix(String text) {
-        int pos = text.indexOf(':');
-        return pos == -1 ? text : text.substring(pos + 1);
+        return text.replaceFirst("(^classpath\\:|^file\\:)", "");
     }
 
     private static final ClassLoader CLASS_LOADER = ResourceUtils.class.getClassLoader();


### PR DESCRIPTION
fixes removal of "drive letter" in windows path that didn't work for vscode debuger



- Relevant Issues : https://github.com/intuit/karate/issues/1373
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
