### PR TITLE
allow "match contains" with empty expectations object to be true

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/match/MatchOperation.java
+++ b/karate-core/src/main/java/com/intuit/karate/match/MatchOperation.java
@@ -475,6 +475,9 @@ public class MatchOperation {
         if (type == MatchType.CONTAINS_ANY) {
             return fail("no key-values matched");
         }
+        if (unMatchedKeysExp.isEmpty() && (type == MatchType.CONTAINS || type == MatchType.CONTAINS_DEEP)) {
+            return true; // all expected keys matched, expMap was empty in the first place
+        }
         if (!unMatchedKeysExp.isEmpty()) {
             return fail("all key-values did not match, expected has un-matched keys - " + unMatchedKeysExp);
         }


### PR DESCRIPTION
### Description

allow "match contains" with empty expectations object to be true
```
* def foo = { bar: 1, baz: 'hello', ban: 'world' }
# both match will be true
* match foo contains { bar: 1 }
* match foo contains {}
```

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
