### PR TITLE
fix regex language collision in fatjar

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -312,6 +312,7 @@
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                             <mainClass>com.intuit.karate.Main</mainClass>
                                         </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     </transformers>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### Description

Fixes the following error:
> org.graalvm.polyglot.PolyglotException: SyntaxError: No language for id regex found. Supported languages are: [js]

Which occurs when a regular expression is used.
E.g. add the following line to `karate-config.js`
```javascript
karate.log('a'.replace(/a/g, 'b'))
```

- Relevant Issues : https://github.com/intuit/karate/issues/1373#issuecomment-747255745
- Relevant PRs : n/a
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
