### PR TITLE
allow RuntimeHooks toq be set in command line

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -216,7 +216,7 @@ public class Main implements Callable<Void> {
             } catch (Exception e) {
                 logger.error("Error instantiating RuntimeHook for {}", hookClassName, e);
             }
-            logger.error("Provided Hook/FactoryClass({}) is not an RuntimeHook or RuntimeHookFactory");
+            logger.error("Provided Hook/FactoryClass({}) is not an RuntimeHook or RuntimeHookFactory", hookClassName);
         }
         return null;
     }

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -149,7 +149,9 @@ public class Runner {
         options.tags = tags;
         options.paths = paths;
         options.scenarioName = scenarioName;
-        options.hooks = hooks;
+        if (hooks != null) {
+            options.hooks.addAll(hooks);
+        }
         options.reportDir = reportDir;
         return options.parallel(threadCount);
     }
@@ -172,7 +174,7 @@ public class Runner {
         List<String> paths;
         List<Feature> features;
         String relativeTo;
-        Collection<RuntimeHook> hooks;
+        final Collection<RuntimeHook> hooks = new ArrayList();
         RuntimeHookFactory hookFactory;
         HttpClientFactory clientFactory;
         boolean forTempUse;
@@ -251,9 +253,6 @@ public class Runner {
             // hooks
             if (hookFactory != null) {
                 hook(hookFactory.create());
-            }
-            if (hooks == null) {
-                hooks = Collections.EMPTY_LIST;
             }
             // features
             if (features == null) {
@@ -422,14 +421,19 @@ public class Runner {
         }
 
         public Builder hook(RuntimeHook hook) {
-            if (hooks == null) {
-                hooks = new ArrayList();
-            }
             if (hook != null) {
                 hooks.add(hook);
             }
             return this;
         }
+
+        public Builder hooks(Collection<RuntimeHook> hooks) {
+            if (hooks != null) {
+                this.hooks.addAll(hooks);
+            }
+            return this;
+        }
+
 
         public Builder hookFactory(RuntimeHookFactory hookFactory) {
             this.hookFactory = hookFactory;

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -425,7 +425,9 @@ public class Runner {
             if (hooks == null) {
                 hooks = new ArrayList();
             }
-            hooks.add(hook);
+            if (hook != null) {
+                hooks.add(hook);
+            }
             return this;
         }
 

--- a/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
+++ b/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
@@ -26,10 +26,13 @@ package com.intuit.karate.cli;
 import com.intuit.karate.Main;
 import com.intuit.karate.Runner;
 import com.intuit.karate.StringUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.intuit.karate.shell.Command;
 import picocli.CommandLine;
 
 /**
@@ -100,7 +103,7 @@ public class IdeMain {
         } else {
             nameTemp = null;
         }
-        Main options = CommandLine.populateCommand(new Main(), line.split("\\s+"));
+        Main options = CommandLine.populateCommand(new Main(), Command.tokenize(line));
         options.setName(nameTemp);
         return options;
     }

--- a/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
+++ b/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
@@ -103,7 +103,7 @@ public class IdeMain {
         } else {
             nameTemp = null;
         }
-        Main options = CommandLine.populateCommand(new Main(), Command.tokenize(line));
+        Main options = Main.parseKarateOptionAndQuotePath(line);
         options.setName(nameTemp);
         return options;
     }

--- a/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
+++ b/karate-core/src/main/java/com/intuit/karate/cli/IdeMain.java
@@ -100,9 +100,7 @@ public class IdeMain {
         } else {
             nameTemp = null;
         }
-        String path = line.trim();
-        Main options = new Main();
-        options.addPath(path);
+        Main options = CommandLine.populateCommand(new Main(), line.split("\\s+"));
         options.setName(nameTemp);
         return options;
     }

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -401,6 +401,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
         runnerThread = new Thread(() -> {
             Runner.path(options.getPaths())
                     .hookFactory(this)
+                    .hook(options.createHook())
                     .tags(options.getTags())
                     .scenarioName(options.getName())
                     .parallel(options.getThreads());

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -401,7 +401,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
         runnerThread = new Thread(() -> {
             Runner.path(options.getPaths())
                     .hookFactory(this)
-                    .hook(options.createHook())
+                    .hooks(options.createHooks())
                     .tags(options.getTags())
                     .scenarioName(options.getName())
                     .parallel(options.getThreads());

--- a/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
@@ -76,9 +76,9 @@ class IdeMainTest {
     void testAbsolutePath() {
         String[] args = new String[]{"/Users/pthomas3/dev/zcode/karate/karate-junit4/src/test/resources/com/intuit/karate/junit4/demos/users.feature"};
         Main options = IdeMain.parseStringArgs(args);
-        assertEquals(1, options.paths.size());        
+        assertEquals(1, options.paths.size());
     }
-    
+
     @Test
     void testPartialKarateOptionsFromSystemProperties() {
         String line = "--tags @e2e";
@@ -87,4 +87,24 @@ class IdeMainTest {
         assertEquals("@e2e", options.tags.get(0));
     }
 
+    @Test
+    void testParseKarateOptionAndQuotePath() {
+        final String[] lines = new String[]{
+                "/tmp/name with spaces.feature",
+                " /tmp/name with spaces.feature ",
+                "-H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature",
+                " -H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ",
+                "-H com.intuit.karate.RuntimeHook \"/tmp/name with spaces.feature\"",
+                " -H com.intuit.karate.RuntimeHook \"/tmp/name with spaces.feature\" ",
+                "-H com.intuit.karate.RuntimeHook '/tmp/name with spaces.feature'",
+                "-H com.intuit.karate.RuntimeHook -H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ",
+                "-H com.intuit.karate.RuntimeHook,com.intuit.karate.RuntimeHook /tmp/name with spaces.feature "
+        };
+
+        for (String line : lines) {
+            Main options = Main.parseKarateOptionAndQuotePath(line);
+            assertEquals(1, options.paths.size());
+            assertEquals("/tmp/name with spaces.feature", options.paths.get(0));
+        }
+    }
 }


### PR DESCRIPTION
### Description

This PR allows to set RuntimeHooks from command line options when using Main cli.

 I'm planning to use these hooks to send runtime information to vscode over a socket in order to implement network logs and other functionality.


- Relevant Issues : #1389
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
