### PR TITLE
fix regex language collision in fatjar / certify fatjar using demo test suite

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -312,6 +312,7 @@
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                             <mainClass>com.intuit.karate.Main</mainClass>
                                         </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     </transformers>
                                 </configuration>
                             </execution>

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -67,7 +67,13 @@
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>2.2.8</version>
-        </dependency>                                                                                  
+        </dependency>
+        <dependency>
+            <groupId>com.intuit.karate</groupId>
+            <artifactId>karate-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>
@@ -206,6 +212,57 @@
                             </execution>                             
                         </executions>                
                     </plugin>                     
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- certify karate-core artifact with demo test suite -->
+            <id>pre-release</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-junit4</artifactId>
+                    <version>${project.version}</version>
+                    <scope>compile</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.intuit.karate</groupId>
+                            <artifactId>karate-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-core</artifactId>
+                    <version>${project.version}</version>
+                    <scope>compile</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.intuit.karate</groupId>
+                            <artifactId>karate-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-core-jar</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${project.basedir}/../karate-core/target/karate-core-${project.version}.jar</systemPath>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>demo/DemoTestParallel.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -72,7 +72,7 @@
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>               
         <dependency>
             <groupId>net.masterthought</groupId>
@@ -164,6 +164,14 @@
     <profiles>
         <profile>
             <id>coverage</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-junit4</artifactId>
+                    <version>${project.version}</version>
+                    <scope>compile</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -200,7 +208,46 @@
                     </plugin>                     
                 </plugins>
             </build>
-        </profile>    
+        </profile>
+        <profile>
+            <!-- certify fat jar with demo test suite -->
+            <id>fatjar</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-junit4</artifactId>
+                    <version>${project.version}</version>
+                    <scope>compile</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.intuit.karate</groupId>
+                            <artifactId>karate-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.intuit.karate</groupId>
+                    <artifactId>karate-core-fatjar</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${project.basedir}/../karate-core/target/karate-${project.version}.jar</systemPath>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>demo/DemoTestParallel.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
     
 </project>

--- a/karate-demo/src/test/java/demo/simple/SimpleRunner.java
+++ b/karate-demo/src/test/java/demo/simple/SimpleRunner.java
@@ -1,0 +1,20 @@
+package demo.simple;
+
+import com.intuit.karate.junit4.Karate;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author jkeys089
+ */
+@RunWith(Karate.class)
+public class SimpleRunner {
+
+    @BeforeClass
+    public static void beforeClass() {
+        // skip 'callSingle' in karate-config.js
+        System.setProperty("karate.env", "mock");
+    }
+
+}

--- a/karate-demo/src/test/java/demo/simple/simple.feature
+++ b/karate-demo/src/test/java/demo/simple/simple.feature
@@ -1,0 +1,5 @@
+Feature: simple sanity checks that should never fail
+
+  Scenario: using regular expressions doesn't cause an exception
+
+    * print 'regex ng'.replace(/ng/, 'ok')


### PR DESCRIPTION
### Description

Fixes the following error:
> org.graalvm.polyglot.PolyglotException: SyntaxError: No language for id regex found. Supported languages are: [js]

Which occurs when a regular expression is used.
E.g. add the following line to `karate-config.js`
```javascript
karate.log('a'.replace(/a/g, 'b'))
```

To build and certify the fatjar use: `mvn clean install -P fatjar -pl karate-core,karate-demo`

- Relevant Issues : https://github.com/intuit/karate/issues/1373#issuecomment-747255745
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
