### PR TITLE
#1409 - fix Karate mock server slow to start up under certain circumstances

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
@@ -93,9 +93,9 @@ public class MockHandler implements ServerHandler {
         runtime.engine.setVariable(ACCEPT_CONTAINS, (Function<String, Boolean>) this::acceptContains);
         runtime.engine.setVariable(HEADER_CONTAINS, (BiFunction<String, String, Boolean>) this::headerContains);
         runtime.engine.setVariable(BODY_PATH, (Function<String, Object>) this::bodyPath);
+        runtime.engine.init();
         if (feature.isBackgroundPresent()) {
             ScenarioEngine.set(runtime.engine);
-            runtime.engine.init();
             for (Step step : feature.getBackground().getSteps()) {
                 Result result = StepRuntime.execute(step, runtime.actions);
                 if (result.isFailed()) {


### PR DESCRIPTION
Fix for issue #1409 tested using the examples provided there.

I assume this fix works because it initialises the JSEngine a bit earlier than it may do otherwise