### PR TITLE
Allow setting params with null value (compatibility with 0.9.6)

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -46,6 +46,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyObject;
 import org.slf4j.Logger;
@@ -376,7 +378,10 @@ public class HttpRequestBuilder implements ProxyObject {
         if (params == null) {
             params = new HashMap();
         }
-        params.put(name, values);
+        List<String> notNullValues = values.stream().filter(v -> v != null).collect(Collectors.toList());
+        if (!notNullValues.isEmpty()) {
+            params.put(name, notNullValues);
+        }
         return this;
     }
 


### PR DESCRIPTION
### Description

In previous version 0.9.6 karate was resilient ignoring params set with a null value, in latest 0.9.9.RC2 this throws an error

We would like to keep relying on previous behavior as it feels more resilient.

- Relevant Issues : https://github.com/intuit/karate/issues/1373#issuecomment-756206383
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
