### PR TITLE
- Adding possibility of setting env, configDir and disable html repor…

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -94,11 +94,8 @@ public class Main implements Callable<Void> {
     @Option(names = {"-o", "--output"}, description = "directory where logs and reports are output (default 'target')")
     String output = FileUtils.getBuildDir();
 
-    @Option(names = {"-r", "--htmlreport"}, description = "output html report enabled (default 'true')")
-    boolean outputHtmlReport = true;
-
-    @Option(names = {"-f", "--format"}, split = ",", description = "report output formats in addition to html e.g. '-f junit,cucumber'"
-            + " [cucumber: Cucumber JSON, junit: JUnit XML]")
+    @Option(names = {"-f", "--format"}, split = ",", description = "comma separate report output formats. tilde excludes the output report. html report is included by default unless it's negated." +
+            "e.g. '-f json,cucumber:json,junit:xml. Possible values [html: Karate HTML, json: Karate JSON, cucumber:json: Cucumber JSON, junit:xml: JUnit XML]")
     List<String> formats;
 
     @Option(names = {"-n", "--name"}, description = "scenario name")
@@ -165,20 +162,20 @@ public class Main implements Callable<Void> {
         this.name = name;
     }
 
+    public List<String> getFormats() {
+        return formats;
+    }
+
+    public void setFormats(List<String> formats) {
+        this.formats = formats;
+    }
+
     public String getOutput() {
         return output;
     }
 
     public void setOutput(String output) {
         this.output = output;
-    }
-
-    public boolean isOutputHtmlReport() {
-        return outputHtmlReport;
-    }
-
-    public void setOutputHtmlReport(boolean outputHtmlReport) {
-        this.outputHtmlReport = outputHtmlReport;
     }
 
     public String getEnv() {
@@ -320,11 +317,13 @@ public class Main implements Callable<Void> {
             server.waitSync();
             return null;
         }
+        boolean outputHtmlReport = false;
         boolean outputCucumberJson = false;
         boolean outputJunitXml = false;
         if (formats != null) {
-            outputCucumberJson = formats.contains("cucumber");
-            outputJunitXml = formats.contains("junit");
+            outputHtmlReport = !formats.contains("~html");
+            outputCucumberJson = formats.contains("cucumber:json");
+            outputJunitXml = formats.contains("junit:xml");
         }
         if (paths != null) {
             Results results = Runner

--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -94,6 +94,9 @@ public class Main implements Callable<Void> {
     @Option(names = {"-o", "--output"}, description = "directory where logs and reports are output (default 'target')")
     String output = FileUtils.getBuildDir();
 
+    @Option(names = {"-r", "--htmlreport"}, description = "output html report enabled (default 'true')")
+    boolean outputHtmlReport = true;
+
     @Option(names = {"-f", "--format"}, split = ",", description = "report output formats in addition to html e.g. '-f junit,cucumber'"
             + " [cucumber: Cucumber JSON, junit: JUnit XML]")
     List<String> formats;
@@ -160,6 +163,38 @@ public class Main implements Callable<Void> {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public boolean isOutputHtmlReport() {
+        return outputHtmlReport;
+    }
+
+    public void setOutputHtmlReport(boolean outputHtmlReport) {
+        this.outputHtmlReport = outputHtmlReport;
+    }
+
+    public String getEnv() {
+        return env;
+    }
+
+    public void setEnv(String env) {
+        this.env = env;
+    }
+
+    public String getConfigDir() {
+        return configDir;
+    }
+
+    public void setConfigDir(String configDir) {
+        this.configDir = configDir;
     }
 
     public static Main parseKarateOptions(String line) {
@@ -298,6 +333,7 @@ public class Main implements Callable<Void> {
                     .workingDir(workingDir)
                     .buildDir(output)
                     .configDir(configDir)
+                    .outputHtmlReport(outputHtmlReport)
                     .outputCucumberJson(outputCucumberJson)
                     .outputJunitXml(outputJunitXml)
                     .dryRun(dryRun)

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServer.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServer.java
@@ -49,9 +49,14 @@ public class DapServer {
     private final Channel channel;
     private final String host;
     private final int port;
+    private final boolean exitAfterDisconnect;
     
     public int getPort() {
         return port;
+    }
+
+    public boolean exitAfterDisconnect() {
+        return exitAfterDisconnect;
     }
 
     public void waitSync() {
@@ -68,10 +73,15 @@ public class DapServer {
         workerGroup.shutdownGracefully();
         logger.info("stop: shutdown complete");
     }    
-    
+
     public DapServer(int requestedPort) {
+        this(requestedPort, true);
+    }
+
+    public DapServer(int requestedPort, boolean exitAfterDisconnect) {
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
+        this.exitAfterDisconnect = exitAfterDisconnect;
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -409,6 +409,10 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
                     .hookFactory(this)
                     .hooks(options.createHooks())
                     .tags(options.getTags())
+                    .reportDir(options.getOutput())
+                    .configDir(options.getConfigDir())
+                    .karateEnv(options.getEnv())
+                    .outputHtmlReport(options.isOutputHtmlReport())
                     .scenarioName(options.getName())
                     .parallel(options.getThreads());
             // if we reached here, run was successful
@@ -441,8 +445,12 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
         channel.eventLoop().execute(()
                 -> channel.writeAndFlush(event("exited")
                         .body("exitCode", 0)));
-        server.stop();
-        System.exit(0);
+        if (server.exitAfterDisconnect()) {
+            server.stop();
+            System.exit(0);
+        } else {
+            channel.disconnect();
+        }
     }
 
     protected long nextFrameId() {

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -404,6 +404,11 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
         if (runnerThread != null) {
             runnerThread.interrupt();
         }
+
+        boolean outputHtmlReport = options.getFormats() != null && !options.getFormats().contains("~html");
+        boolean outputCucumberJson = options.getFormats() != null && options.getFormats().contains("cucumber:json");
+        boolean outputJunitXml = options.getFormats() != null && options.getFormats().contains("junit:xml");
+
         runnerThread = new Thread(() -> {
             Runner.path(options.getPaths())
                     .hookFactory(this)
@@ -412,7 +417,9 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
                     .reportDir(options.getOutput())
                     .configDir(options.getConfigDir())
                     .karateEnv(options.getEnv())
-                    .outputHtmlReport(options.isOutputHtmlReport())
+                    .outputHtmlReport(outputHtmlReport)
+                    .outputCucumberJson(outputCucumberJson)
+                    .outputJunitXml(outputJunitXml)
                     .scenarioName(options.getName())
                     .parallel(options.getThreads());
             // if we reached here, run was successful

--- a/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+
 /**
  *
  * @author pthomas3
@@ -70,6 +72,20 @@ class IdeMainTest {
         Main options = IdeMain.parseIdeCommandLine(INTELLIJ6);
         assertEquals(1, options.paths.size());
         assertEquals("/Users/pthomas3/dev/zcode/temp/my co test/src/test/java/examples/users/users.feature", options.paths.get(0));
+    }
+
+    @Test
+    void testParsingCommandLineReportFormats() {
+        Main options = IdeMain.parseIdeCommandLine("cucumber.api.cli.Main --plugin org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome -e local -f html,json,cucumber:json,junit:xml -g /dev/config/dir /dev/test/todos.feature:27");
+        System.out.println();
+
+        assertIterableEquals(options.formats, new ArrayList<String>() { { add("html"); add("json"); add("cucumber:json"); add("junit:xml"); }});
+
+        Main options2 = IdeMain.parseIdeCommandLine("cucumber.api.cli.Main --plugin org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome -e local -f json,cucumber:json,junit:xml -g /dev/config/dir /dev/test/todos.feature:27");
+        assertIterableEquals(options2.formats, new ArrayList<String>() { { add("json"); add("cucumber:json"); add("junit:xml"); }});
+
+        Main options3 = IdeMain.parseIdeCommandLine("cucumber.api.cli.Main --plugin org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome -e local -f ~html,json,cucumber:json,junit:xml -g /dev/config/dir /dev/test/todos.feature:27");
+        assertIterableEquals(options3.formats, new ArrayList<String>() { { add("~html"); add("json"); add("cucumber:json"); add("junit:xml"); }});
     }
 
     @Test


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

> Adding parameter that allows debug server to be reused - when debug session terminates VS Code disconnects but debug server continues to run

As I run my own framework on top of Karate one of the things that I always wanted to avoid was the System.exit() that happens after the debug session. I used to have some weird workarounds with the Java Security Manager but introduced a variable (exitAfterDisconnect) which allows that behavior to be controlled. With it you can create a debug that doesn't terminate the JVM (just disconnects the session) server by extending DapServer class and setting that parameter as false.

The behavior from VS Studio Code is just that the debug session will terminate so it's seamless to the user.

> Adding possibility of setting env, configDir and disable html report via debugger in VS Code

With Karate v1.0.0 allowing env to be passed in the runner and a configDir I externalized all configurations and use variables in all test cases but the debugger needs to run against a certain environment. This allows the parameters to be passed in the karateOptions of the Karate Runner in VS Code. Here's an example of the field in the Runner:

"karateOptions": "\\"${command:karateRunner.getDebugFile}\\" \\"--configdir=C:\\\\test_cases\\\\config\\" \\"--env=dev01\\"",

@ptrthomas let me know your thoughts. Might be good to tag the maintainer of the Karate Runner to check it out.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
