### PR TITLE
Fixing issues with debugger from VS Studio where after a few nested calls to features on other folders the debugger didn't stop on the breakpoint

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -37,6 +37,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Map.Entry;
@@ -105,7 +106,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
 
     protected boolean isBreakpoint(Step step, int line) {
         Feature feature = step.getFeature();
-        String path = feature.getResource().getFile().getPath();
+        String path = normalizePath(feature.getResource().getFile().getPath());
         int pos = findPos(path);
         SourceBreakpoints sb;
         if (pos != -1) {
@@ -117,6 +118,17 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
             return false;
         }
         return sb.isBreakpoint(line);
+    }
+
+    protected String normalizePath(String path) {
+        String normalizedPath = Paths.get(path).normalize().toString();
+        if(FileUtils.isOsWindows() && path.matches("^[a-zA-Z]:\\\\.*")) {
+            // in Windows if the first character is the drive, let's capitalize it
+            // Windows paths are case insensitive but in the debugger it mostly comes capitalized but sometimes
+            // VS Studio sends the paths with the first letter lower case
+            normalizedPath = normalizedPath.substring(0, 1).toUpperCase() + normalizedPath.substring(1);
+        }
+        return normalizedPath;
     }
 
     private DebugThread thread(DapMessage dm) {
@@ -238,7 +250,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
                 break;
             case "setBreakpoints":
                 SourceBreakpoints sb = new SourceBreakpoints(req.getArguments());
-                BREAKPOINTS.put(sb.path, sb);
+                BREAKPOINTS.put(normalizePath(sb.path), sb);
                 logger.trace("source breakpoints: {}", sb);
                 ctx.write(response(req).body("breakpoints", sb.breakpoints));
                 break;


### PR DESCRIPTION
### Description

This was a painful one for me and I just stumbled upon the solution by change. When your feature files call other feature files the debugger was never great and most of the times didn't stop (especially if they were on other sub folders etc). It has always been painful for UI automation as we reuse a lot of features and functions etc.

The problem was that the path of the breakpoint was on this format: C:\test\feature\folder\..\called-feature.feature and the breakpoints are all stored with absolute paths - C:\test\feature\folder\called-feature.feature . Paths.normalize() takes care of that. In addition VS Studio some times passes the path with the driver letter in lower case (e.g. c:\test\feature\folder\called-feature.feature) and so the lookup in the Map also fails.

Case is important because of the BREAKPOINTS.get(). I wondered for a few minutes if we should make it insensitive but that can create problems in Mac/Linux (although why would you have the same file with two different cases in the same folder).

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
