### PR TITLE
Fix parse options with spaces in filenames #1426 #1404

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -207,9 +207,8 @@ public class Main implements Callable<Void> {
             String path = matcher.group(2).trim();
             if (path.contains(" ")) {
                 // unquote if necessary
+                String options = line.substring(0, line.lastIndexOf(path));
                 path = path.replaceAll("^\"|^'|\"$|\'$", "");
-                String options = matcher.group(1);
-                options = options != null ? options : "";
                 line = String.format("%s \"%s\"", options, path);
             }
         }

--- a/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/IdeMainTest.java
@@ -112,9 +112,9 @@ class IdeMainTest {
             " -H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ",
             "-H com.intuit.karate.RuntimeHook \"/tmp/name with spaces.feature\"",
             " -H com.intuit.karate.RuntimeHook \"/tmp/name with spaces.feature\" ",
-            "-H com.intuit.karate.RuntimeHook '/tmp/name with spaces.feature'",
-            "-H com.intuit.karate.RuntimeHook -H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ",
-            "-H com.intuit.karate.RuntimeHook,com.intuit.karate.RuntimeHook /tmp/name with spaces.feature "
+                "-H com.intuit.karate.RuntimeHook '/tmp/name with spaces.feature'",
+                "-H com.intuit.karate.RuntimeHook -H com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ",
+                "-H com.intuit.karate.RuntimeHook,com.intuit.karate.RuntimeHook /tmp/name with spaces.feature "
         };
 
         for (String line : lines) {
@@ -122,6 +122,13 @@ class IdeMainTest {
             assertEquals(1, options.paths.size());
             assertEquals("/tmp/name with spaces.feature", options.paths.get(0));
         }
+
+        String line = "-g C:\\test_cases\\config -e dev01 -H com.intuit.karate.RuntimeHook,com.intuit.karate.RuntimeHook /tmp/name with spaces.feature ";
+        Main options = Main.parseKarateOptionAndQuotePath(line);
+        assertEquals(1, options.paths.size());
+        assertEquals("C:\\test_cases\\config", options.configDir);
+        assertEquals("dev01", options.env);
+        assertEquals("/tmp/name with spaces.feature", options.paths.get(0));
     }
     
 }


### PR DESCRIPTION
### Description

Fix parse options with spaces in filenames #1426 #1404

- Relevant Issues : #1426 #1404
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
