### PR TITLE
prevents "org.graalvm.polyglot.PolyglotException: Java heap space"

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/debug/DapMessage.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapMessage.java
@@ -118,7 +118,7 @@ public class DapMessage {
     }
 
     public String toJson() {
-        return JsonUtils.toJson(toMap());
+        return JsonUtils.toJsonSafe(toMap(), false);
     }
 
     public Map<String, Object> toMap() {

--- a/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/debug/DapServerHandler.java
@@ -379,7 +379,7 @@ public class DapServerHandler extends SimpleChannelInboundHandler<DapMessage> im
                 String varName = expression.substring(0, expression.indexOf('.'));
                 String path = expression.substring(expression.indexOf('.') + 1);
                 Object nested = Json.of(vars.get(varName).getValue()).get(path);
-                result = JsonUtils.toJson(nested);
+                result = JsonUtils.toJsonSafe(nested, true);
             } else {
                 Variable v = vars.get(expression);
                 result = v.getAsPrettyString();


### PR DESCRIPTION
### Description

prevents "org.graalvm.polyglot.PolyglotException: Java heap space" when debugging or printing large objects

- Relevant Issues : https://github.com/intuit/karate/issues/1373#issuecomment-763599330
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
