### PR TITLE
Reproducing issue reported in https://github.com/intuit/karate/issues…

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -1,5 +1,7 @@
 package com.intuit.karate.core;
 
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
 import com.intuit.karate.TestUtils;
 import com.intuit.karate.Match;
 import com.intuit.karate.report.ReportUtils;
@@ -207,6 +209,29 @@ class FeatureRuntimeTest {
     @Test
     void testOutlineBackground() {
         run("outline-background.feature");
-    }    
+    }
 
+
+    @Test
+    void testScenarioUsingFunctionDefinedThroughConfigJsFile() {
+        Feature feature = Feature.read("classpath:com/intuit/karate/core/test-with-js-function.feature");
+        Runner.Builder builder = Runner.builder();
+        //builder.karateEnv(env);
+        builder.configDir("src/test/java/com/intuit/karate/core");
+        builder.features(feature);
+        Results results = builder.parallel(2);
+        assertEquals(0, results.getFailCount());
+    }
+
+
+    @Test
+    void testScenarioUsingFunctionDefinedThroughConfigJsFileParallel() {
+        Feature feature = Feature.read("classpath:com/intuit/karate/core/test-with-js-function-2.feature");
+        Runner.Builder builder = Runner.builder();
+        //builder.karateEnv(env);
+        builder.configDir("src/test/java/com/intuit/karate/core");
+        builder.features(feature);
+        Results results = builder.parallel(3);
+        assertEquals(0, results.getFailCount());
+    }
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/ScenarioRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/ScenarioRuntimeTest.java
@@ -91,10 +91,12 @@ class ScenarioRuntimeTest {
         run(
                 "def foo = configUtilsJs.someText",
                 "def bar = configUtilsJs.someFun()",
-                "def res = call read('called2.feature')"
+                "def res = call read('called2.feature')",
+                "def test = configUtils.hello()"
         );
         matchVar("foo", "hello world");
         matchVar("bar", "hello world");
+        matchVar("test", "{ helloVar: 'hello world' }");
         Match.that(get("res")).contains("{ calledBar: 'hello world' }");
         System.clearProperty("karate.env");
         System.clearProperty("karate.config.dir");

--- a/karate-core/src/test/java/com/intuit/karate/core/test-with-js-function-2.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/test-with-js-function-2.feature
@@ -1,0 +1,10 @@
+Feature: Test Feature with function from global config
+
+Background:
+  * def data = [ { name: 'value' }, { name: 'value2' }, { name: 'value3' }, { name: 'value4' } ]
+
+Scenario Outline:
+  * print 'test'
+
+Examples:
+  | data |

--- a/karate-core/src/test/java/com/intuit/karate/core/test-with-js-function.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/test-with-js-function.feature
@@ -1,0 +1,17 @@
+Feature: Test Feature with function from global config
+
+Background:
+  * def data = [ { name: 'value' }, { name: 'value2' }, { name: 'value3' }, { name: 'value4' } ]
+
+Scenario Outline:
+  * def foo = configUtilsJs.someText
+  * def bar = configUtilsJs.someFun()
+  * def res = call read('called2.feature')
+  * def test = configUtils.hello()
+  * match foo == 'hello world'
+  * match bar == 'hello world'
+  * match res contains { calledBar: 'hello world' }
+  * match test == { helloVar: 'hello world' }
+
+Examples:
+  | data |

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.0-LOCAL</version>
     </parent>
     
     <artifactId>karate-demo</artifactId>


### PR DESCRIPTION
don't merge - just reproducing my comment here: https://github.com/intuit/karate/issues/1452#issuecomment-767943021

@ptrthomas  the second unit test in `FeatureRuntimeTest.java` calling `test-with-js-function-2.feature` is sufficient to reproduce. This is the error:
```
20:33:24.776 [pool-1-thread-2] ERROR com.intuit.karate - scenario [run] failed
Multi threaded access requested by thread Thread[pool-1-thread-2,5,main] but is not allowed for language(s) js.
20:33:24.797 [pool-1-thread-2] ERROR com.intuit.karate - scenario [run] failed
Multi threaded access requested by thread Thread[pool-1-thread-2,5,main] but is not allowed for language(s) js.
20:33:24.822 [pool-1-thread-3] ERROR com.intuit.karate - scenario [run] failed
Multi threaded access requested by thread Thread[pool-1-thread-3,5,main] but is not allowed for language(s) js.
20:33:24.844 [pool-1-thread-1] INFO  com.intuit.karate - [print] test 
```

This is only reproduceable with Scenario Outline with dynamic data as Examples (if we use a static table, not an issue neither for normal scenarios).

If we comment both the following lines from the `karate-config.js` the issue isn't reproduced anymore.
`configUtils: karate.call('classpath:com/intuit/karate/core/karate-config-utils.feature')`
   
```
 configUtilsJs: {
      //someFun: function () {
      //  return 'hello world'
      //}
    },
```

My gut tells me it's related to the fact that we run the background section and then reattach all the variables from there into each iteration of the ScenarioIteration. 