### PR TITLE
fixes reading yml files with an array as root element

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/JsonUtils.java
@@ -157,7 +157,7 @@ public class JsonUtils {
         return (T) fromJson(s, clazz.getName());
     }
 
-    public static Map<String, Object> fromYaml(String raw) {
+    public static Object fromYaml(String raw) {
         Yaml yaml = new Yaml(new SafeConstructor());
         return yaml.load(raw);
     }


### PR DESCRIPTION
### Description

fixes reading yml files with an array as root element

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
