### PR TITLE
add interval to karate.range() and allow reverse ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3193,7 +3193,7 @@ Operation | Description
 <a name="karate-prettyxml"><code>karate.prettyXml(value)</code></a> | return a 'pretty-printed', nicely indented string representation of the XML value, also see: [`print`](#print)
 <a name="karate-prevrequest"><code>karate.prevRequest</code></a> | for advanced users, you can inspect the *actual* HTTP request after it happens, useful if you are writing a framework over Karate, refer to this example: [`request.feature`](karate-demo/src/test/java/demo/request/request.feature)
 <a name="karate-properties"><code>karate.properties[key]</code></a> | get the value of any Java system-property by name, useful for [advanced custom configuration](#dynamic-port-numbers)
-<a name="karate-range"><code>karate.range(start, end)</code></a> | returns a JSON array of integers (inclusive)
+<a name="karate-range"><code>karate.range(start, end, [interval])</code></a> | returns a JSON array of integers (inclusive), the optional third argument must be a positive integer and defaults to 1, and if start < end the order of values is reversed
 <a name="karate-read"><code>karate.read(filename)</code></a> | the same [`read()`](#reading-files) function - which is pre-defined even within JS blocks, so there is no need to ever do `karate.read()`, and just `read()` is sufficient
 <a name="karate-readasstring"><code>karate.readAsString(filename)</code></a> | [rarely used](#read-file-as-string), behaves exactly like [`read`](#reading-files) - but does *not* auto convert to JSON or XML
 <a name="karate-remove"><code>karate.remove(name, path)</code></a> | very rarely used - when needing to perform conditional removal of JSON keys or XML nodes. Behaves the same way as the [`remove`](#remove) keyword.

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioBridge.java
@@ -591,9 +591,22 @@ public class ScenarioBridge implements PerfContext {
     }
     
     public Object range(int start, int end) {
+        return range(start, end, 1);
+    }
+
+    public Object range(int start, int end, int interval) {
+        if (interval <= 0) {
+            throw new RuntimeException("interval must be a positive integer");
+        }
         List<Integer> list = new ArrayList();
-        for (int i = start; i <= end; i++) {
-            list.add(i);
+        if (start <= end) {
+            for (int i = start; i <= end; i += interval) {
+                list.add(i);
+            }
+        } else {
+            for (int i = start; i >= end; i -= interval) {
+                list.add(i);
+            }
         }
         return JsValue.fromJava(list);
     }

--- a/karate-core/src/test/java/com/intuit/karate/core/ScenarioRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/ScenarioRuntimeTest.java
@@ -719,13 +719,24 @@ class ScenarioRuntimeTest {
                 "match res2 == [{ val: 'A' }, { val: 'B' }, { val: 'C' }]"
         );
     }
-    
+
     @Test
     void testRange() {
         run(
-                "def list = karate.range(5, 10)",
-                "match list == [5, 6, 7, 8, 9, 10]"
-        );        
+                "def list1 = karate.range(5, 10)",
+                "match list1 == [5, 6, 7, 8, 9, 10]",
+                "def list2 = karate.range(5, 10, 2)",
+                "match list2 == [5, 7, 9]",
+                "def list3 = karate.range(10, 5, 2)",
+                "match list3 == [10, 8, 6]"
+        );
+        fail = true;
+        run(
+                "def list = karate.range(10, 5, 0)"
+        );
+        run(
+                "def list = karate.range(10, 5, -1)"
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description

Extends the new karate.range() method to support an optional 3rd argument for the interval. Also allows start and end to be reversed.
```
  * match list1 == [5, 6, 7, 8, 9, 10]",
  * def list2 = karate.range(5, 10, 2)",
  * match list2 == [5, 7, 9]",
  * def list3 = karate.range(10, 5, 2)",
  * match list3 == [10, 8, 6]"
```
Docs updated and tests also confirm that an interval of <= 0 will fail to avoid infinite loops.

- Relevant Issues : none
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
