### PR TITLE
Make auto-conversion of response bodies sensitive to Content-Type header

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -579,7 +579,7 @@ public class ScenarioEngine {
             body = bytes;
         } else {
             try {
-                body = JsValue.fromBytes(bytes, true);
+                body = JsValue.fromBytes(bytes, true, resourceType);
             } catch (Exception e) {
                 body = FileUtils.toString(bytes);
                 logger.warn("auto-conversion of response failed: {}", e.getMessage());

--- a/karate-core/src/main/java/com/intuit/karate/graal/JsValue.java
+++ b/karate-core/src/main/java/com/intuit/karate/graal/JsValue.java
@@ -26,6 +26,7 @@ package com.intuit.karate.graal;
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.XmlUtils;
 import com.intuit.karate.JsonUtils;
+import com.intuit.karate.http.ResourceType;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -241,17 +242,20 @@ public class JsValue {
         }
     }
 
-    public static Object fromBytes(byte[] bytes, boolean jsonStrict) {
+    public static Object fromBytes(byte[] bytes, boolean jsonStrict, ResourceType resourceType) {
         if (bytes == null) {
             return null;
         }
         String raw = FileUtils.toString(bytes);
-        return fromString(raw, jsonStrict);
+        return fromString(raw, jsonStrict, resourceType);
     }
 
-    public static Object fromString(String raw, boolean jsonStrict) {
+    public static Object fromString(String raw, boolean jsonStrict, ResourceType resourceType) {
         String trimmed = raw.trim();
         if (trimmed.isEmpty()) {
+            return raw;
+        }
+        if (resourceType != null && !resourceType.isJson() && !resourceType.isXml() && !resourceType.isText()) {
             return raw;
         }
         switch (trimmed.charAt(0)) {
@@ -267,7 +271,7 @@ public class JsValue {
 
     public static Object fromStringSafe(String raw) {
         try {
-            return fromString(raw, false);
+            return fromString(raw, false, null);
         } catch (Exception e) {
             logger.trace("failed to auto convert: {}", e + "");
             return raw;

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
@@ -130,7 +130,7 @@ public class HttpLogger {
         } else {
             Object converted = request.getBodyForDisplay();
             if (converted == null) {
-                converted = JsValue.fromBytes(request.getBody(), false);
+                converted = JsValue.fromBytes(request.getBody(), false, rt);
             }
             logBody(config, requestModifier, sb, uri, converted, true);
         }

--- a/karate-core/src/main/java/com/intuit/karate/http/Request.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Request.java
@@ -280,7 +280,7 @@ public class Request implements ProxyObject {
             return body;
         }
         try {
-            return JsValue.fromBytes(body, false);
+            return JsValue.fromBytes(body, false, rt);
         } catch (Exception e) {
             logger.trace("failed to auto-convert response: {}", e);
             return getBodyAsString();

--- a/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
@@ -164,6 +164,9 @@ public enum ResourceType {
         }
         ct = ct.toLowerCase();
         for (ResourceType rt : ResourceType.values()) {
+            if (ct.equals(rt.contentType)) {
+                return rt;
+            }
             for (String like : rt.contentLike) {
                 if (ct.contains(like)) {
                     return rt;

--- a/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ResourceType.java
@@ -47,7 +47,14 @@ public enum ResourceType {
     XML("application/xml", vals("xml"), vals("xml")),
     TEXT("text/plain", vals("plain"), vals("txt")),
     MULTIPART("multipart/form-data", vals("multipart"), vals()),
-    BINARY("application/octet-stream", vals("octet"), vals());
+    BINARY("application/octet-stream", vals("octet"), vals()),
+    RDFXML("application/rdf+xml", vals("xml", "rdf"), vals(".rdf")),
+    NTRIPLES("application/n-triples", vals("rdf"), vals(".nt")),
+    TURTLE("text/turtle", vals("rdf"), vals(".ttl")),
+    NQUADS("application/n-quads", vals("rdf"), vals(".nq")),
+    TRIG("application/trig", vals("rdf"), vals(".trig")),
+    N3("text/n3", vals("rdf"), vals(".n3")),
+    JSONLD("application/ld+json", vals("json", "rdf"), vals(".jsonld"));
 
     private static String[] vals(String... values) {
         return values;
@@ -112,13 +119,29 @@ public enum ResourceType {
         }
     }
 
-    public boolean isHtml() {
-        return this == HTML;
-    }
+    public boolean isHtml() { return this == HTML; }
 
     public boolean isJson() {
-        return this == JSON;
+        switch (this) {
+            case JSON:
+            case JSONLD:
+                return true;
+            default:
+                return false;
+        }
     }
+
+    public boolean isXml() {
+        switch (this) {
+            case XML:
+            case RDFXML:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isText() { return this == TEXT; }
 
     public boolean isBinary() {
         switch (this) {

--- a/karate-core/src/main/java/com/intuit/karate/http/Response.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Response.java
@@ -149,7 +149,7 @@ public class Response implements ProxyObject {
             return body;
         }
         try {
-            return JsValue.fromBytes(body, false);
+            return JsValue.fromBytes(body, false, rt);
         } catch (Exception e) {
             logger.trace("failed to auto-convert response: {}", e);
             return getBodyAsString();

--- a/karate-core/src/main/java/com/intuit/karate/http/ServerContext.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/ServerContext.java
@@ -238,7 +238,7 @@ public class ServerContext implements ProxyObject {
     }
     
     private static final Supplier<String> UUID_FUNCTION = () -> java.util.UUID.randomUUID().toString();
-    private final Function<String, Object> FROM_JSON_FUNCTION = s -> JsValue.fromString(s, false);
+    private final Function<String, Object> FROM_JSON_FUNCTION = s -> JsValue.fromString(s, false, null);
     private final Methods.FunVar HTTP_FUNCTION; // set in constructor
     
     private final Consumer<String> SWITCH_FUNCTION = s -> {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -189,14 +189,15 @@ class KarateMockHandlerTest {
     void testResponseContentTypeForJson() {
         background().scenario(
                 "pathMatches('/hello')",
-                "def response = { foo: 'bar'}");
+                "def responseHeaders = { 'Content-Type': 'application/json' }",
+                "def response = '{ \"foo\": \"bar\"}'");
         run(
                 URL_STEP,
                 "path '/hello'",
                 "method get",
                 "match responseHeaders == { 'Content-Type': ['application/json'] }",
                 "match header content-type == 'application/json'",
-                "match header content-type contains 'json'"
+                "match responseType == 'json'"
         );
     }
 
@@ -345,6 +346,82 @@ class KarateMockHandlerTest {
                 "method get"
         );
         matchVar("responseHeaders", "{ 'content-type': ['text/html'] }");
+    }
+
+    @Test
+    void testResponseContentTypeForXml() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = { 'Content-Type': 'application/xml' }",
+                "def response = '<hello>world</hello>'");
+        run(
+                URL_STEP,
+                "path '/hello'",
+                "method get",
+                "match header content-type == 'application/xml'",
+                "match responseType == 'xml'",
+                "match response.hello == 'world'"
+        );
+    }
+
+    @Test
+    void testResponseAutoConversionForXmlAsPlainText() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = '<hello>world</hello>'");
+        run(
+                URL_STEP,
+                "path '/hello'",
+                "method get",
+                "match header content-type == 'text/plain'",
+                "match responseType == 'xml'",
+                "match response.hello == 'world'"
+        );
+    }
+
+    @Test
+    void testResponseAutoConversionForJsonAsPlainText() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = '{ \"foo\": \"bar\"}'");
+        run(
+                URL_STEP,
+                "path '/hello'",
+                "method get",
+                "match header content-type == 'text/plain'",
+                "match responseType == 'json'",
+                "match response.foo == 'bar'"
+        );
+    }
+
+    @Test
+    void testResponseAutoConversionForTextWithTags() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def response = '<http://example.org/#hello> a <http://example.org/#greeting> .'");
+        run(
+                URL_STEP,
+                "path '/hello'",
+                "method get",
+                "match header content-type == 'text/plain'",
+                "match responseType == 'string'",
+                "match response == '<http://example.org/#hello> a <http://example.org/#greeting> .'"
+        );
+    }
+    @Test
+    void testResponseContentTypeForNonXmlWithTags() {
+        background().scenario(
+                "pathMatches('/hello')",
+                "def responseHeaders = { 'Content-Type': 'text/turtle' }",
+                "def response = '<http://example.org/#hello> a <http://example.org/#greeting> .'");
+        run(
+                URL_STEP,
+                "path '/hello'",
+                "method get",
+                "match header content-type == 'text/turtle'",
+                "match responseType == 'string'",
+                "match response == '<http://example.org/#hello> a <http://example.org/#greeting> .'"
+        );
     }
 
 }


### PR DESCRIPTION
### Description

Presently, any response body that starts with `<` is auto-converted to XML but if it is not XML there is still a fatal error reported. This PR attempts to avoid that by checking the resource type before converting. It tries to avoid breaking existing behaviour by ensuring any response body that is of an ambiguous type will be handled as it was previously.

The resource type is passed (when available) into the JsValue converter. There is then a test to see if there is a ResourceType defined and if it is explicitly not a known JSON or XML (or plain text) format, then auto conversion is not attempted. I added a number of RDF media types that may start with a `<` but cannot be parsed as XML.

If you are happy with this approach, it could allow for the optional addition in the future of an RDFUtils class to convert any RDF types to triples. I wanted to take this one step at a time since you are rightly concerned not to break existing tests. 
One thing to note is that there are other XML conversions where an HTTP response and content type is not present. I suspect that if RDF were to be handled in these places too, then we would need a way to improve the isXml function to do more than check the first character. You may decide that is a step too far but this I think this PR still has value on its own as it will prevent the incorrect fatal error messages.

All tests pass but I wasn't sure where to add some additional tests for this change. If you can point me in the right direction I can add them to the PR.

- Relevant Issues : #1462 
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
