### PR TITLE
Changed log level from [warn] to [debug] for "over-writing existing variables"

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -1286,7 +1286,7 @@ public class ScenarioEngine {
         name = StringUtils.trimToEmpty(name);
         validateVariableName(name); // always validate when gherkin
         if (vars.containsKey(name)) {
-            logger.warn("over-writing existing variable '{}' with new value: {}", name, exp);
+            logger.debug("over-writing existing variable '{}' with new value: {}", name, exp);
         }
         if (assignType == AssignType.TEXT) {
             setVariable(name, exp);


### PR DESCRIPTION
### Description
Changed log level from `warn` to `debug` for `over-writing existing variable '{}' with new value: {}` since it's not really a warning and it increases the log size especially when executing performance test where we only want to check for actionable warnings.

- Relevant Issues : [1523](https://github.com/intuit/karate/issues/1523)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation