### PR TITLE
Fix HttpLogger to output urlencoded POST bodies

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
@@ -27,6 +27,7 @@ import com.intuit.karate.Logger;
 import com.intuit.karate.graal.JsValue;
 import com.intuit.karate.core.Config;
 import com.intuit.karate.core.Variable;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -124,10 +125,10 @@ public class HttpLogger {
         sb.append("request:\n").append(requestCount).append(" > ")
                 .append(request.getMethod()).append(' ').append(maskedUri);
         logHeaders(requestCount, " > ", sb, requestModifier, request.getHeaders());
-        ResourceType rt = ResourceType.fromContentType(request.getContentType());
-        if (rt == null || rt.isBinary()) {
-            // don't log body
-        } else {
+        String contentType = request.getContentType();
+        ResourceType rt = ResourceType.fromContentType(contentType);
+        if ((contentType != null && contentType.contains("application/x-www-form-urlencoded")) || (rt != null && !rt.isBinary())) {
+            // log body
             Object converted = request.getBodyForDisplay();
             if (converted == null) {
                 try {
@@ -165,5 +166,4 @@ public class HttpLogger {
         }
         logger.debug("{}", sb);
     }
-
 }


### PR DESCRIPTION
### Description

This PR fixes #1525 by ensuring that `HttpLogger` attempts to log the body when the content type is `application/x-www-form-urlencoded`. I initially tried adding that as a `ResourceType` but this caused other tests to fail as `RequestHandler` assumes that anything with a `ResourceType` is a static resource. In the end I felt there was no option but to add a special case to handling this content type within the `HttpLogger`. I also felt the logic became clearer by inverting the if and dropping the empty block. I hope this is a suitable solution.

- Relevant Issues : #1525 
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
