### PR TITLE
Make karate unix launcher work from any directory

### DIFF
--- a/examples/zip-release/karate
+++ b/examples/zip-release/karate
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -cp karate.jar:. com.intuit.karate.Main $*
+java -cp "$(dirname "$0")/karate.jar":. com.intuit.karate.Main "$@"


### PR DESCRIPTION
This change means you can run the `karate` script from any directory, e.g., `path/to/karate` or if you add it to `PATH` it should work too.

Previously this would happen.
```
$ karate-1.0.0/karate --help
Error: Could not find or load main class com.intuit.karate.Main
Caused by: java.lang.ClassNotFoundException: com.intuit.karate.Main
```
