### PR TITLE
[mobile] Added enhancements for `wait` API for mobile UI

### DIFF
--- a/examples/mobile-test/src/test/java/android/AndroidTest.java
+++ b/examples/mobile-test/src/test/java/android/AndroidTest.java
@@ -5,7 +5,7 @@ import com.intuit.karate.junit5.Karate;
 /**
  * @author babusekaran
  */
-class AndroidRunner {
+class AndroidTest {
 
     @Karate.Test
     public Karate test() {

--- a/examples/mobile-test/src/test/java/android/android.feature
+++ b/examples/mobile-test/src/test/java/android/android.feature
@@ -9,7 +9,7 @@ Feature: android test
     And driver.clear('#com.bs.droidaction:id/showTextOnDelay').input("10000")
     And driver.input('#com.bs.droidaction:id/editTextBox', "KarateDSL")
     And driver.click('#com.bs.droidaction:id/showTextCheckBox')
-    And retry(5, 3000).waitForAny("#com.bs.droidaction:id/nameTextView", "//android.widget.TextView[@text='KarateDSL']")
+    And retry(10, 1000).waitForAny("#com.bs.droidaction:id/nameTextView", "//android.widget.TextView[@text='KarateDSL']")
     Then match driver.text('#com.bs.droidaction:id/nameTextView') == 'KarateDSL'
     And driver.click('#com.bs.droidaction:id/showTextCheckBox')
     And assert (optional('#com.bs.droidaction:id/nameTextView').present != true)

--- a/examples/mobile-test/src/test/java/android/android.feature
+++ b/examples/mobile-test/src/test/java/android/android.feature
@@ -5,9 +5,11 @@ Feature: android test
 
   Scenario: android mobile app UI tests
     Given driver { webDriverSession: { desiredCapabilities : "#(android.desiredConfig)"} }
-    And driver.input('#com.bs.droidaction:id/editTextBox', "UI demo")
-    And driver.click('#com.bs.droidaction:id/clearButton')
-    And driver.input('#com.bs.droidaction:id/editTextBox', "Karate DSL")
-    Then match driver.text('#com.bs.droidaction:id/nameTextView') == 'Karate DSL'
     And driver.click('#com.bs.droidaction:id/showTextCheckBox')
-    And match driver.text('#com.bs.droidaction:id/nameTextView') == ''
+    And driver.clear('#com.bs.droidaction:id/showTextOnDelay').input("10000")
+    And driver.input('#com.bs.droidaction:id/editTextBox', "KarateDSL")
+    And driver.click('#com.bs.droidaction:id/showTextCheckBox')
+    And retry(5, 3000).waitForAny("#com.bs.droidaction:id/nameTextView", "//android.widget.TextView[@text='KarateDSL']")
+    Then match driver.text('#com.bs.droidaction:id/nameTextView') == 'KarateDSL'
+    And driver.click('#com.bs.droidaction:id/showTextCheckBox')
+    And assert (optional('#com.bs.droidaction:id/nameTextView').present != true)

--- a/examples/mobile-test/src/test/java/karate-config.js
+++ b/examples/mobile-test/src/test/java/karate-config.js
@@ -2,7 +2,7 @@ function fn() {
   var config = {}
   var android = {}
   android["desiredConfig"] = {
-   "app" : "https://github.com/babusekaran/droidAction/raw/master/build/UiDemo.apk",
+   "app" : "https://github.com/babusekaran/droidAction/raw/main/build/UiDemo.apk",
    "newCommandTimeout" : 300,
    "platformVersion" : "9.0",
    "platformName" : "Android",

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AndroidDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AndroidDriver.java
@@ -2,7 +2,6 @@ package com.intuit.karate.driver.appium;
 
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.core.ScenarioRuntime;
-import com.intuit.karate.driver.DriverOptions;
 import java.util.Map;
 
 /**
@@ -10,12 +9,12 @@ import java.util.Map;
  */
 public class AndroidDriver extends AppiumDriver {
 
-    protected AndroidDriver(DriverOptions options) {
+    protected AndroidDriver(MobileDriverOptions options) {
         super(options);
     }
 
     public static AndroidDriver start(Map<String, Object> map, ScenarioRuntime sr) {
-        DriverOptions options = new DriverOptions(map, sr, 4723, FileUtils.isOsWindows() ? "cmd.exe" : "appium");
+        MobileDriverOptions options = new MobileDriverOptions(map, sr, 4723, FileUtils.isOsWindows() ? "cmd.exe" : "appium");
         // additional commands needed to start appium on windows
         if (FileUtils.isOsWindows()){
             options.arg("/C");

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
@@ -177,26 +177,6 @@ public abstract class AppiumDriver extends WebDriver {
     }
 
     @Override
-    public boolean waitUntil(String expression) {
-        if (isWebSession) {
-            return super.waitUntil(expression);
-        }
-        return options.retry(() -> {
-            try {
-                String json = selectorPayload(expression);
-                Response res = http.path("element").postJson(json);
-                if (isLocatorError(res)) {
-                    return false;
-                }
-                return true;
-            } catch (Exception e) {
-                logger.warn("waitUntil evaluate failed: {}", e.getMessage());
-                return false;
-            }
-        }, b -> b, "waitUntil (js)", true);
-    }
-
-    @Override
     protected <T> T retryIfEnabled(String locator, Supplier<T> action) {
         if (isWebSession) {
             return super.retryIfEnabled(locator, action);

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/IosDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/IosDriver.java
@@ -1,7 +1,6 @@
 package com.intuit.karate.driver.appium;
 
 import com.intuit.karate.core.ScenarioRuntime;
-import com.intuit.karate.driver.DriverOptions;
 import java.util.Map;
 
 /**
@@ -9,12 +8,12 @@ import java.util.Map;
  */
 public class IosDriver extends AppiumDriver {
 
-    public IosDriver(DriverOptions options) {
+    public IosDriver(MobileDriverOptions options) {
         super(options);
     }
 
     public static IosDriver start(Map<String, Object> map, ScenarioRuntime sr) {
-        DriverOptions options = new DriverOptions(map, sr, 4723, "appium");
+        MobileDriverOptions options = new MobileDriverOptions(map, sr, 4723, "appium");
         options.arg("--port=" + options.port);
         return new IosDriver(options);
     }

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/MobileDriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/MobileDriverOptions.java
@@ -1,0 +1,82 @@
+package com.intuit.karate.driver.appium;
+
+import com.intuit.karate.core.ScenarioRuntime;
+import com.intuit.karate.driver.DriverOptions;
+import com.intuit.karate.driver.Driver;
+import com.intuit.karate.driver.Element;
+import com.intuit.karate.driver.DriverElement;
+import com.intuit.karate.driver.MissingElement;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author babusekaran
+ */
+public class MobileDriverOptions extends DriverOptions {
+
+    public MobileDriverOptions(Map<String, Object> options, ScenarioRuntime sr, int defaultPort, String defaultExecutable) {
+        super(options, sr, defaultPort, defaultExecutable);
+    }
+
+    public boolean isWebSession() {
+        // flag to know if driver runs for browser on mobile
+        Map<String, Object> sessionPayload = super.getWebDriverSessionPayload();
+        Map<String, Object> desiredCapabilities = (Map<String, Object>) sessionPayload.get("desiredCapabilities");
+        return  (desiredCapabilities.get("browserName") != null) ? true : false;
+    }
+
+    @Override
+    public Element waitForAny(Driver driver, String... locators) {
+        if (isWebSession()) {
+            return super.waitForAny(driver, locators);
+        }
+        long startTime = System.currentTimeMillis();
+        List<String> list = Arrays.asList(locators);
+        Iterator<String> iterator = list.iterator();
+        boolean found = false;
+        while (iterator.hasNext()) {
+            String locator = iterator.next();
+            found = optional(driver, locator).isPresent();
+            if (found) {
+                break; // break, when at-least one element found
+            }
+        }
+        // important: un-set the retry flag
+        disableRetry();
+        if (!found) {
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            throw new RuntimeException("wait failed for: " + list + " after " + elapsedTime + " milliseconds");
+        }
+        if (locators.length == 1) {
+            return DriverElement.locatorExists(driver, locators[0]);
+        }
+        for (String locator : locators) {
+            Element temp = driver.optional(locator);
+            if (temp.isPresent()) {
+                return temp;
+            }
+        }
+        // this should never happen
+        throw new RuntimeException("unexpected wait failure for locators: " + list);
+
+    }
+
+    @Override
+    public Element optional(Driver driver, String locator) {
+        if (isWebSession()) {
+            return super.optional(driver, locator);
+        }
+        try{
+            driver.waitUntil(locator);
+            // the element exists, if the above function did not throw an exception
+            return DriverElement.locatorExists(driver, locator);
+        }
+        catch (RuntimeException re) {
+            return new MissingElement(driver, locator);
+        }
+    }
+
+}


### PR DESCRIPTION
**Approach:**
created a mobile-specific options `MobileDriverOptions` to override functions according to mobile driver needs

Added enhancements for below wait APIs to ensure it works for mobile,

- `waitFor(locator)`
- `waitForAny(locator1, locator2,... locatorN)`
- `waitForText(locator, text)`

**Bonus changes:**

1. changes to support other relevant APIs on mobile like `optional()`, `exists()`, `clear()` 
2. added wait related examples to [mobile-test](https://github.com/intuit/karate/tree/master/examples/mobile-test) and points to updated demo app.

> only `waitUntil(function)` is expected to work for mobile, other overload for `waitUntil()` may work for mobile-web but not supported on mobile apps.




- Relevant Issues : https://github.com/intuit/karate/issues/1548
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
