### PR TITLE
Introduce path encoding (fixes #1561)

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ function fn() {
 }
 ```
 
-> Here above, you see the [`karate.log()`](#karate-log), [`karate.env`](#karate-env) and [`karate.configure()`](#karate-configure) "helpers" being used. Note that the `karate-config.js` is re-processed for *every* `Scenario` and in rare cases, you may want to initialize (e.g. auth tokens) only once for all of your tests. This can be achieved using [`karate.callSingle()`](#karate-callsingle).
+> Here above, you see the [`karate.log()`](#karate-log), [`karate.env`](#karate-env) and [`karate.configure()`](#karate-configure) "helpers" being used. Note that the `karate-config.js` is re-processed for *every* `Scenario` and in rare cases, you may want to initialize (e.g. auth tokens) only once for all of your tests. This can be achieved using [`karate.callSingle()`](#karatecallsingle).
 
 A common requirement is to pass dynamic parameter values via the command line, and you can use the [`karate.properties['some.name']`](#karate-properties) syntax for getting a system property passed via JVM options in the form `-Dsome.name=foo`. Refer to the section on [dynamic port numbers](#dynamic-port-numbers) for an example.
 
@@ -3912,6 +3912,8 @@ Refer to this example:
 * [`headers-single.feature`](karate-demo/src/test/java/demo/headers/headers-single.feature)
 
 You *can* use `karate.callSingle()` directly in a `*.feature` file, but it logically fits better in the global "bootstrap". Ideally it should return "pure JSON" and note that you always get a "deep clone" of the cached result object.
+
+IMPORTANT: There are some restrictions when using `karate.callSingle()` especially within [`karate-config.js`](#karate-configjs). Ideally you should return only *pure* JSON data (or a primitive string, number etc.). Keep in mind that the reason this exists is to "cache" data, and *not* behavior. So if you return complex objects such as a custom Java instance or a JS function that depends on complex objects, this [will cause issues when you run in parallel](https://github.com/intuit/karate/issues/1558).
 
 #### `configure callSingleCache`
 When re-running tests in development mode and when your test suite depends on say an `Authorization` header set by [`karate.callSingle()`](#karatecallsingle), you can cache the results locally to a file, which is very convenient when your "auth token" is valid for a period of a few minutes - which typically is the case. This means that as long as the token "on file" is valid, you can save time by not having to make the one or two HTTP calls needed to "sign-in" or create "throw-away" users in your SSO store.

--- a/README.md
+++ b/README.md
@@ -1059,7 +1059,7 @@ A [special case](#remove-if-null) of embedded expressions can remove a JSON key 
   * [`match`](#match)
   * [`configure`](#configure)
 * and when you [`read()`](#reading-files) a JSON or XML file
-* the expression *has* to start with `"#(` and end with `)`
+* the expression *has* to start with `#(` and end with `)`
   
 Because of the last rule above, note that string-concatenation may not work quite the way you expect:
 

--- a/examples/mobile-test/src/test/java/android/AndroidTest.java
+++ b/examples/mobile-test/src/test/java/android/AndroidTest.java
@@ -5,7 +5,7 @@ import com.intuit.karate.junit5.Karate;
 /**
  * @author babusekaran
  */
-class AndroidRunner {
+class AndroidTest {
 
     @Karate.Test
     public Karate test() {

--- a/examples/mobile-test/src/test/java/android/android.feature
+++ b/examples/mobile-test/src/test/java/android/android.feature
@@ -5,9 +5,11 @@ Feature: android test
 
   Scenario: android mobile app UI tests
     Given driver { webDriverSession: { desiredCapabilities : "#(android.desiredConfig)"} }
-    And driver.input('#com.bs.droidaction:id/editTextBox', "UI demo")
-    And driver.click('#com.bs.droidaction:id/clearButton')
-    And driver.input('#com.bs.droidaction:id/editTextBox', "Karate DSL")
-    Then match driver.text('#com.bs.droidaction:id/nameTextView') == 'Karate DSL'
     And driver.click('#com.bs.droidaction:id/showTextCheckBox')
-    And match driver.text('#com.bs.droidaction:id/nameTextView') == ''
+    And driver.clear('#com.bs.droidaction:id/showTextOnDelay').input("10000")
+    And driver.input('#com.bs.droidaction:id/editTextBox', "KarateDSL")
+    And driver.click('#com.bs.droidaction:id/showTextCheckBox')
+    And retry(10, 1000).waitForAny("#com.bs.droidaction:id/nameTextView", "//android.widget.TextView[@text='KarateDSL']")
+    Then match driver.text('#com.bs.droidaction:id/nameTextView') == 'KarateDSL'
+    And driver.click('#com.bs.droidaction:id/showTextCheckBox')
+    And assert (optional('#com.bs.droidaction:id/nameTextView').present != true)

--- a/examples/mobile-test/src/test/java/karate-config.js
+++ b/examples/mobile-test/src/test/java/karate-config.js
@@ -2,7 +2,7 @@ function fn() {
   var config = {}
   var android = {}
   android["desiredConfig"] = {
-   "app" : "https://github.com/babusekaran/droidAction/raw/master/build/UiDemo.apk",
+   "app" : "https://github.com/babusekaran/droidAction/raw/main/build/UiDemo.apk",
    "newCommandTimeout" : 300,
    "platformVersion" : "9.0",
    "platformName" : "Android",

--- a/karate-archetype/pom.xml
+++ b/karate-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-archetype</artifactId>
     <packaging>jar</packaging>

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -1159,7 +1159,7 @@ Note that the "opposite" of `optional()` is [`locate()`](#locate) which will fai
 If all you need to do is check whether an element exists and fail the test if it doesn't, see [`exists()`](#exists) below.
 
 ## `exists()`
-This method returns a boolean (`true` or `false`), perfect for asserting if an element exists and failing the test if not.
+This method returns a boolean (`true` or `false`), perfect for asserting if an element exists and giving you the option to perform conditional logic, or manually fail the test using something like [`karate.fail()`](https://github.com/intuit/karate#karate-fail) if needed.
 
 ## `waitUntil()`
 Wait for the *browser* JS expression to evaluate to `true`. Will poll using the [retry()](#retry) settings configured.

--- a/karate-core/README.md
+++ b/karate-core/README.md
@@ -1824,10 +1824,10 @@ Scenario:
 ## `driver.emulateDevice()`
 Emulating a device is supported natively only by type: `chrome`. You need to call a method on the `driver` object directly:
 
-The example below has the width, height and userAgent for iPhone X.
+The example below has the `width`, `height` and [`userAgent`](https://wicg.github.io/ua-client-hints/) for an iPhone X.
 
 ```cucumber
-  And driver.emulateDevice(375, 812, 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1')
+And driver.emulateDevice(375, 812, 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1')
 ```
 
 # File Upload

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-core</artifactId>
     <packaging>jar</packaging>   

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -145,7 +145,7 @@ public class Suite implements Runnable {
             featureResultFiles = null;
             workingDir = FileUtils.WORKING_DIR;
             buildDir = FileUtils.getBuildDir();
-            reportDir = null;
+            reportDir = FileUtils.getBuildDir();
             karateBase = null;
             karateConfig = null;
             karateConfigEnv = null;

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioEngine.java
@@ -886,6 +886,10 @@ public class ScenarioEngine {
             setRobot(robot);
         }
     }
+    
+    public void setDriverToNull() {
+        this.driver = null;
+    }
 
     public void setDriver(Driver driver) {
         this.driver = driver;

--- a/karate-core/src/main/java/com/intuit/karate/core/ScenarioOutline.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScenarioOutline.java
@@ -86,7 +86,7 @@ public class ScenarioOutline {
         boolean examplesHaveTags = examplesTables.stream().anyMatch(t -> !t.getTags().isEmpty());
         for (ExamplesTable examples : examplesTables) {
             boolean selectedForExecution = false;
-            if (fr != null && examplesHaveTags) {
+            if (fr != null && examplesHaveTags && fr.caller.isNone()) {
                 // getting examples in the context of an execution
                 // if the examples do not have any tagged example, do not worry about selecting
                 Tags tableTags = Tags.merge(examples.getTags());
@@ -97,7 +97,6 @@ public class ScenarioOutline {
             } else {
                 selectedForExecution = true;
             }
-
             if (selectedForExecution) {
                 Table table = examples.getTable();
                 if (table.isDynamic()) {

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -365,7 +365,6 @@ public abstract class DevToolsDriver implements Driver {
     }
 
     public void emulateDevice(int width, int height, String userAgent) {
-        logger.info("Setting deviceMetrics width={}, height={}, userAgent={}", width, height, userAgent);
         method("Network.setUserAgentOverride").param("userAgent", userAgent).send();
         method("Emulation.setDeviceMetricsOverride")
                 .param("width", width)

--- a/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DevToolsDriver.java
@@ -393,6 +393,7 @@ public abstract class DevToolsDriver implements Driver {
         if (command != null) {
             command.close(true);
         }
+        getRuntime().engine.setDriverToNull();
     }
 
     @Override

--- a/karate-core/src/main/java/com/intuit/karate/driver/DockerTarget.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DockerTarget.java
@@ -136,7 +136,7 @@ public class DockerTarget implements Target {
         }
         File copy = new File(buildDir + File.separator + dirName + ".mp4");
         FileUtils.copy(file, copy);
-        return Collections.singletonMap("video", "../" + copy.getName());
+        return Collections.singletonMap("video", copy.getPath());
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/DriverOptions.java
@@ -282,14 +282,14 @@ public class DriverOptions {
         String type = (String) options.get("type");
         if (type == null) {
             sr.logger.warn("type was null, defaulting to 'chrome'");
-            type = "chrome";
+            type = Chrome.DRIVER_TYPE;
             options.put("type", type);
         }
         try { // to make troubleshooting errors easier
             switch (type) {
-                case "chrome":
+                case Chrome.DRIVER_TYPE:
                     return Chrome.start(options, sr);
-                case "msedge":
+                case EdgeChromium.DRIVER_TYPE:
                     return EdgeChromium.start(options, sr);
                 case "chromedriver":
                     return ChromeWebDriver.start(options, sr);
@@ -313,7 +313,7 @@ public class DriverOptions {
                     return PlaywrightDriver.start(options, sr);
                 default:
                     sr.logger.warn("unknown driver type: {}, defaulting to 'chrome'", type);
-                    options.put("type", "chrome");
+                    options.put("type", Chrome.DRIVER_TYPE);
                     return Chrome.start(options, sr);
             }
         } catch (Exception e) {
@@ -433,7 +433,7 @@ public class DriverOptions {
                     locator = locator.substring(1);
                 } else {
                     locator = "(." + locator.substring(2);
-                }                 
+                }
             } else if (!DOCUMENT.equals(contextNode)) {
                 locator = "." + locator; // evaluate relative to this node not root
             }

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AndroidDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AndroidDriver.java
@@ -2,7 +2,6 @@ package com.intuit.karate.driver.appium;
 
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.core.ScenarioRuntime;
-import com.intuit.karate.driver.DriverOptions;
 import java.util.Map;
 
 /**
@@ -10,12 +9,12 @@ import java.util.Map;
  */
 public class AndroidDriver extends AppiumDriver {
 
-    protected AndroidDriver(DriverOptions options) {
+    protected AndroidDriver(MobileDriverOptions options) {
         super(options);
     }
 
     public static AndroidDriver start(Map<String, Object> map, ScenarioRuntime sr) {
-        DriverOptions options = new DriverOptions(map, sr, 4723, FileUtils.isOsWindows() ? "cmd.exe" : "appium");
+        MobileDriverOptions options = new MobileDriverOptions(map, sr, 4723, FileUtils.isOsWindows() ? "cmd.exe" : "appium");
         // additional commands needed to start appium on windows
         if (FileUtils.isOsWindows()){
             options.arg("/C");

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/AppiumDriver.java
@@ -29,6 +29,7 @@ import com.intuit.karate.driver.DriverOptions;
 import com.intuit.karate.driver.Element;
 import com.intuit.karate.driver.WebDriver;
 import com.intuit.karate.http.ResourceType;
+import com.intuit.karate.http.Response;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -37,20 +38,21 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.function.Supplier;
 
 /**
  * @author babusekaran
  */
 public abstract class AppiumDriver extends WebDriver {
 
-    private boolean isBrowserSession;
+    private boolean isWebSession;
 
-    protected AppiumDriver(DriverOptions options) {
+    protected AppiumDriver(MobileDriverOptions options) {
         super(options);
         // flag to know if driver runs for browser on mobile
         Map<String, Object> sessionPayload = (Map<String, Object>) options.getWebDriverSessionPayload();
         Map<String, Object> desiredCapabilities = (Map<String, Object>) sessionPayload.get("desiredCapabilities");
-        isBrowserSession = (desiredCapabilities.get("browserName") != null) ? true : false;
+        isWebSession = (desiredCapabilities.get("browserName") != null) ? true : false;
     }
 
     @Override
@@ -61,7 +63,7 @@ public abstract class AppiumDriver extends WebDriver {
 
     @Override
     protected String selectorPayload(String id) {
-        if (isBrowserSession) { // use WebDriver selector strategies for mobile browser
+        if (isWebSession) { // use WebDriver selector strategies for mobile browser
             return super.selectorPayload(id);
         }
         Json json = Json.object();
@@ -158,7 +160,7 @@ public abstract class AppiumDriver extends WebDriver {
 
     @Override
     public Object script(String expression) {
-        if (isBrowserSession) { // use WebDriver script for mobile browser
+        if (isWebSession) { // use WebDriver script for mobile browser
             return super.script(expression);
         }
         return eval(expression).getValue();
@@ -172,6 +174,49 @@ public abstract class AppiumDriver extends WebDriver {
         List<Map<String, Object>> scriptArgs = new ArrayList<>(1);
         scriptArgs.add(args);
         return eval(expression, scriptArgs).getValue();
+    }
+
+    @Override
+    protected <T> T retryIfEnabled(String locator, Supplier<T> action) {
+        if (isWebSession) {
+            return super.retryIfEnabled(locator, action);
+        }
+        if (options.isRetryEnabled()) {
+            waitFor(locator); // will throw exception if not found
+        }
+        return action.get();
+    }
+
+    @Override
+    public DriverOptions getOptions() {
+        if (isWebSession) {
+            return super.getOptions();
+        }
+        return (MobileDriverOptions)options;
+    }
+
+    @Override
+    public Element waitForText(String locator, String expected) {
+        if (isWebSession) {
+            return super.waitForText(locator, expected);
+        }
+        return (Element) waitUntil(() -> {
+            String text = optional(locator).getText();
+            if (!expected.equals(text)) {
+                return null;
+            }
+            return DriverElement.locatorExists(this, locator);
+        });
+    }
+
+    @Override
+    public Element clear(String locator) {
+        if (isWebSession) {
+            return super.clear(locator);
+        }
+        String id = elementId(locator);
+        http.path("element", id, "clear").postJson("{}");
+        return DriverElement.locatorExists(this, locator);
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/IosDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/IosDriver.java
@@ -1,7 +1,6 @@
 package com.intuit.karate.driver.appium;
 
 import com.intuit.karate.core.ScenarioRuntime;
-import com.intuit.karate.driver.DriverOptions;
 import java.util.Map;
 
 /**
@@ -9,12 +8,12 @@ import java.util.Map;
  */
 public class IosDriver extends AppiumDriver {
 
-    public IosDriver(DriverOptions options) {
+    public IosDriver(MobileDriverOptions options) {
         super(options);
     }
 
     public static IosDriver start(Map<String, Object> map, ScenarioRuntime sr) {
-        DriverOptions options = new DriverOptions(map, sr, 4723, "appium");
+        MobileDriverOptions options = new MobileDriverOptions(map, sr, 4723, "appium");
         options.arg("--port=" + options.port);
         return new IosDriver(options);
     }

--- a/karate-core/src/main/java/com/intuit/karate/driver/appium/MobileDriverOptions.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/appium/MobileDriverOptions.java
@@ -1,0 +1,92 @@
+package com.intuit.karate.driver.appium;
+
+import com.intuit.karate.core.ScenarioRuntime;
+import com.intuit.karate.driver.DriverOptions;
+import com.intuit.karate.driver.Driver;
+import com.intuit.karate.driver.Element;
+import com.intuit.karate.driver.DriverElement;
+import com.intuit.karate.driver.MissingElement;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author babusekaran
+ */
+public class MobileDriverOptions extends DriverOptions {
+
+    public MobileDriverOptions(Map<String, Object> options, ScenarioRuntime sr, int defaultPort, String defaultExecutable) {
+        super(options, sr, defaultPort, defaultExecutable);
+    }
+
+    public boolean isWebSession() {
+        // flag to know if driver runs for browser on mobile
+        Map<String, Object> sessionPayload = super.getWebDriverSessionPayload();
+        Map<String, Object> desiredCapabilities = (Map<String, Object>) sessionPayload.get("desiredCapabilities");
+        return  (desiredCapabilities.get("browserName") != null) ? true : false;
+    }
+
+    @Override
+    public Element waitForAny(Driver driver, String... locators) {
+        if (isWebSession()) {
+            return super.waitForAny(driver, locators);
+        }
+        long startTime = System.currentTimeMillis();
+        List<String> list = Arrays.asList(locators);
+        boolean found = (boolean)driver.waitUntil(() -> {
+            for (String locator: list) {
+                try {
+                    ((AppiumDriver)driver).elementId(locator);
+                    return true;
+                }
+                catch (RuntimeException re){
+                    logger.debug("failed to locate : {}", locator);
+                }
+            }
+            return null;
+        });
+        // important: un-set the retry flag
+        disableRetry();
+        if (!found) {
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            throw new RuntimeException("wait failed for: " + list + " after " + elapsedTime + " milliseconds");
+        }
+        if (locators.length == 1) {
+            return DriverElement.locatorExists(driver, locators[0]);
+        }
+        for (String locator : locators) {
+            Element temp = driver.optional(locator);
+            if (temp.isPresent()) {
+                return temp;
+            }
+        }
+        // this should never happen
+        throw new RuntimeException("unexpected wait failure for locators: " + list);
+
+    }
+
+    @Override
+    public Element optional(Driver driver, String locator) {
+        if (isWebSession()) {
+            return super.optional(driver, locator);
+        }
+        try{
+            retry(() -> {
+                try {
+                    ((AppiumDriver)driver).elementId(locator);
+                    return true;
+                } catch (RuntimeException re) {
+                    return false;
+                }
+            }, b -> b, "optional (locator)", true);
+            // the element exists, if the above function did not throw an exception
+            return DriverElement.locatorExists(driver, locator);
+        }
+        catch (RuntimeException re) {
+            return new MissingElement(driver, locator);
+        }
+    }
+
+}

--- a/karate-core/src/main/java/com/intuit/karate/driver/chrome/Chrome.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/chrome/Chrome.java
@@ -25,6 +25,8 @@ package com.intuit.karate.driver.chrome;
 
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.Http;
+import com.intuit.karate.core.FeatureRuntime;
+import com.intuit.karate.core.ScenarioEngine;
 import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.shell.Command;
 import com.intuit.karate.driver.DevToolsDriver;
@@ -40,6 +42,8 @@ import java.util.Map;
  * @author pthomas3
  */
 public class Chrome extends DevToolsDriver {
+    
+    public static final String DRIVER_TYPE = "chrome";
 
     public static final String DEFAULT_PATH_MAC = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
     public static final String DEFAULT_PATH_WIN = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe";
@@ -62,8 +66,8 @@ public class Chrome extends DevToolsDriver {
             options.arg("--headless");
         }
         Command command = options.startProcess();
-        Http http = options.getHttp();
-        Command.waitForHttp(http.urlBase + "/json");
+        Http http = options.getHttp();        
+        Command.waitForHttp(http.urlBase + "/json", r -> r.getStatus() == 200 && !r.json().asList().isEmpty());
         Response res = http.path("json").get();
         if (res.json().asList().isEmpty()) {
             if (command != null) {
@@ -108,14 +112,17 @@ public class Chrome extends DevToolsDriver {
         Map<String, Object> options = new HashMap();
         options.put("executable", chromeExecutablePath);
         options.put("headless", headless);
-        return Chrome.start(options, null);
+        return Chrome.start(options);
     }
 
     public static Chrome start(Map<String, Object> options) {
         if (options == null) {
             options = new HashMap();
         }
-        return Chrome.start(options, null);
+        options.putIfAbsent("type", DRIVER_TYPE);
+        ScenarioRuntime runtime = FeatureRuntime.forTempUse().scenarios.next();
+        ScenarioEngine.set(runtime.engine);
+        return Chrome.start(options, runtime);
     }
 
     public static Chrome start() {

--- a/karate-core/src/main/java/com/intuit/karate/driver/microsoft/EdgeChromium.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/microsoft/EdgeChromium.java
@@ -25,6 +25,8 @@ package com.intuit.karate.driver.microsoft;
 
 import com.intuit.karate.FileUtils;
 import com.intuit.karate.Http;
+import com.intuit.karate.core.FeatureRuntime;
+import com.intuit.karate.core.ScenarioEngine;
 import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.driver.DevToolsDriver;
 import com.intuit.karate.driver.DriverOptions;
@@ -41,6 +43,8 @@ import java.util.Map;
  * @author sixdouglas
  */
 public class EdgeChromium extends DevToolsDriver {
+    
+    public static final String DRIVER_TYPE = "msedge";
 
     public static final String DEFAULT_PATH_MAC = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
     public static final String DEFAULT_PATH_WIN = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
@@ -109,17 +113,20 @@ public class EdgeChromium extends DevToolsDriver {
     }
 
     public static EdgeChromium start(String chromeExecutablePath, boolean headless) {
-        Map<String, Object> options = new HashMap<>();
+        Map<String, Object> options = new HashMap();
         options.put("executable", chromeExecutablePath);
         options.put("headless", headless);
-        return EdgeChromium.start(options, null);
+        return EdgeChromium.start(options);
     }
 
     public static EdgeChromium start(Map<String, Object> options) {
         if (options == null) {
-            options = new HashMap<>();
+            options = new HashMap();
         }
-        return EdgeChromium.start(options, null);
+        options.putIfAbsent("type", DRIVER_TYPE);
+        ScenarioRuntime runtime = FeatureRuntime.forTempUse().scenarios.next();
+        ScenarioEngine.set(runtime.engine);        
+        return EdgeChromium.start(options, runtime);
     }
 
     public static EdgeChromium start() {

--- a/karate-core/src/main/java/com/intuit/karate/http/AwsLambdaHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/AwsLambdaHandler.java
@@ -83,7 +83,7 @@ public class AwsLambdaHandler {
         Map<String, Object> res = new HashMap(4);
         res.put(STATUS_CODE, response.getStatus());
         res.put(MULTI_HEADERS, response.getHeaders());
-        boolean isBinary = response.getResourceType().isBinary();
+        boolean isBinary = response.isBinary();
         res.put(IS_BASE64_ENCODED, isBinary);
         byte[] responseBody = response.getBody();
         if (responseBody == null) {

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClientFactory.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClientFactory.java
@@ -34,6 +34,6 @@ public interface HttpClientFactory {
 
     HttpClient create(ScenarioEngine engine);
 
-    public static final HttpClientFactory DEFAULT = engine -> new ApacheHttpClient(engine);
+    HttpClientFactory DEFAULT = ApacheHttpClient::new;
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpLogger.java
@@ -69,7 +69,7 @@ public class HttpLogger {
         }
         Variable v = new Variable(body);
         String text;
-        if (config != null && config.isLogPrettyRequest()) {
+        if (config != null && needsPrettyLogging(config, request)) {
             text = v.getAsPrettyString();
         } else {
             text = v.getAsString();
@@ -78,6 +78,18 @@ public class HttpLogger {
             text = request ? logModifier.request(uri, text) : logModifier.response(uri, text);
         }
         sb.append(text);
+    }
+
+    private static boolean needsPrettyLogging(Config config, boolean request) {
+        return logPrettyRequest(config, request) || logPrettyResponse(config, request);
+    }
+
+    private static boolean logPrettyResponse(Config config, boolean request) {
+        return !request && config.isLogPrettyResponse();
+    }
+
+    private static boolean logPrettyRequest(Config config, boolean request) {
+        return request && config.isLogPrettyRequest();
     }
 
     private static HttpLogModifier logModifier(Config config, String uri) {

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -28,11 +28,11 @@ import com.intuit.karate.StringUtils;
 import com.intuit.karate.graal.JsArray;
 import com.intuit.karate.graal.JsValue;
 import com.intuit.karate.graal.Methods;
-import com.linecorp.armeria.common.QueryParams;
-import com.linecorp.armeria.common.QueryParamsBuilder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +47,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyObject;
 import org.slf4j.Logger;
@@ -84,13 +86,14 @@ public class HttpRequestBuilder implements ProxyObject {
         URL, METHOD, PATH, PARAM, PARAMS, HEADER, HEADERS, BODY, INVOKE,
         GET, POST, PUT, DELETE, PATCH, HEAD, CONNECT, OPTIONS, TRACE
     };
-    private static final Set<String> KEY_SET = new HashSet(Arrays.asList(KEYS));
+    private static final Set<String> KEY_SET = new HashSet<>(Arrays.asList(KEYS));
     private static final JsArray KEY_ARRAY = new JsArray(KEYS);
 
     private String url;
     private String method;
     private List<String> paths;
     private Map<String, List<String>> params;
+    private String fragment;
     private Map<String, List<String>> headers;
     private MultiPartBuilder multiPart;
     private Object body;
@@ -159,14 +162,7 @@ public class HttpRequestBuilder implements ProxyObject {
             }
             multiPart = null;
         }
-        String urlAndPath = getUrlAndPath();
-        if (params != null) {
-            QueryParamsBuilder qpb = QueryParams.builder();
-            params.forEach((k, v) -> qpb.add(k, v));
-            String append = urlAndPath.indexOf('?') == -1 ? "?" : "&";
-            urlAndPath = urlAndPath + append + qpb.toQueryString();
-        }
-        request.setUrl(urlAndPath);
+        request.setUrl(getUri().toASCIIString());
         if (multiPart != null) {
             if (body == null) { // this is not-null only for a re-try, don't rebuild multi-part
                 body = multiPart.build();
@@ -183,7 +179,7 @@ public class HttpRequestBuilder implements ProxyObject {
             request.setBodyForDisplay(multiPart.getBodyForDisplay());
         }
         if (cookies != null && !cookies.isEmpty()) {
-            List<String> cookieValues = new ArrayList(cookies.size());
+            List<String> cookieValues = new ArrayList<>(cookies.size());
             for (Cookie c : cookies) {
                 String cookieValue = ClientCookieEncoder.LAX.encode(c);
                 cookieValues.add(cookieValue);
@@ -245,6 +241,11 @@ public class HttpRequestBuilder implements ProxyObject {
         return this;
     }
 
+    public HttpRequestBuilder fragment(String fragment) {
+        this.fragment = fragment;
+        return this;
+    }
+
     public HttpRequestBuilder paths(String... paths) {
         for (String path : paths) {
             path(path);
@@ -263,32 +264,39 @@ public class HttpRequestBuilder implements ProxyObject {
         return this;
     }
 
-    private String getPath() {
-        String temp = "";
+    private List<String> backwardsCompatiblePaths() {
         if (paths == null) {
-            return temp;
+            return Collections.emptyList();
         }
-        for (String path : paths) {
-            if (path.startsWith("/")) {
+
+        List<String> result = new ArrayList<>(paths.size());
+        for (int i = 0; i < paths.size(); i++) {
+            String path = paths.get(i);
+            if (i == 0 && path.startsWith("/")) {
                 path = path.substring(1);
+                logger.warn("the first path segment starts with a '/', this will be stripped off for now, but in the future this may be escaped and cause your request to fail.");
             }
-            if (!temp.isEmpty() && !temp.endsWith("/")) {
-                temp = temp + "/";
-            }
-            temp = temp + path;
+            result.add(path);
         }
-        return temp;
+        return result;
     }
 
-    public String getUrlAndPath() {
-        if (url == null) {
-            url = "";
+    private URI getUri() {
+        try {
+            URIBuilder builder = url == null ? new URIBuilder() : new URIBuilder(url);
+            if (params != null) {
+                params.forEach((key, values) -> values.forEach(value -> builder.addParameter(key, value)));
+            }
+            // merge paths from the base url with additional paths supplied to this builder
+            List<String> merged = Stream.of(builder.getPathSegments(), backwardsCompatiblePaths())
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            return builder.setPathSegments(merged)
+                    .setFragment(fragment)
+                    .build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
-        String path = getPath();
-        if (path.isEmpty()) {
-            return url;
-        }
-        return url.endsWith("/") ? url + path : url + "/" + path;
     }
 
     public HttpRequestBuilder body(Object body) {
@@ -331,7 +339,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder header(String name, List<String> values) {
         if (headers == null) {
-            headers = new LinkedHashMap();
+            headers = new LinkedHashMap<>();
         }
         for (String key : headers.keySet()) {
             if (key.equalsIgnoreCase(name)) {
@@ -390,7 +398,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder param(String name, List<String> values) {
         if (params == null) {
-            params = new HashMap();
+            params = new HashMap<>();
         }
         List<String> notNullValues = values.stream().filter(v -> v != null).collect(Collectors.toList());
         if (!notNullValues.isEmpty()) {
@@ -417,7 +425,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder cookie(Cookie cookie) {
         if (cookies == null) {
-            cookies = new HashSet();
+            cookies = new HashSet<>();
         }
         cookies.add(cookie);
         return this;
@@ -451,7 +459,7 @@ public class HttpRequestBuilder implements ProxyObject {
     //
     private final Methods.FunVar PATH_FUNCTION = args -> {
         if (args.length == 0) {
-            return getPath();
+            return getUri().getPath();
         } else {
             for (Object o : args) {
                 if (o != null) {
@@ -596,7 +604,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     @Override
     public String toString() {
-        return getUrlAndPath();
+        return getUri().toASCIIString();
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
@@ -64,7 +64,7 @@ public class HttpUtils {
         if (count <= 1) {
             return null;
         }
-        Map<String, String> map = new LinkedHashMap(count - 1);
+        Map<String, String> map = new LinkedHashMap<>(count - 1);
         for (int i = 1; i < count; i++) {
             String item = items.get(i);
             int pos = item.indexOf('=');
@@ -90,7 +90,7 @@ public class HttpUtils {
         if (rightSize != leftSize) {
             return null;
         }
-        Map<String, String> map = new LinkedHashMap(leftSize);
+        Map<String, String> map = new LinkedHashMap<>(leftSize);
         for (int i = 0; i < leftSize; i++) {
             String left = leftList.get(i);
             String right = rightList.get(i);
@@ -107,7 +107,7 @@ public class HttpUtils {
         return map;
     }
 
-    public static final String normaliseUriPath(String uri) {
+    public static String normaliseUriPath(String uri) {
         uri = uri.indexOf('?') == -1 ? uri : uri.substring(0, uri.indexOf('?'));
         if (uri.endsWith("/")) {
             uri = uri.substring(0, uri.length() - 1);
@@ -224,7 +224,7 @@ public class HttpUtils {
 
     private static final HttpResponseStatus CONNECTION_ESTABLISHED = new HttpResponseStatus(200, "Connection established");
 
-    public static final FullHttpResponse connectionEstablished() {
+    public static FullHttpResponse connectionEstablished() {
         return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, CONNECTION_ESTABLISHED);
     }
 
@@ -243,7 +243,7 @@ public class HttpUtils {
         List<String> list;
         if (msg.headers().contains(HttpHeaderNames.VIA)) {
             List<String> existing = msg.headers().getAll(HttpHeaderNames.VIA);
-            list = new ArrayList(existing);
+            list = new ArrayList<>(existing);
             list.add(sb.toString());
         } else {
             list = Collections.singletonList(sb.toString());

--- a/karate-core/src/main/java/com/intuit/karate/http/Request.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Request.java
@@ -92,7 +92,7 @@ public class Request implements ProxyObject {
         PATH, METHOD, PARAM, PARAMS, HEADER, HEADERS, PATH_PARAM, PATH_PARAMS, BODY, MULTI_PART, MULTI_PARTS, JSON, AJAX,
         GET, POST, PUT, DELETE, PATCH, HEAD, CONNECT, OPTIONS, TRACE
     };
-    private static final Set<String> KEY_SET = new HashSet(Arrays.asList(KEYS));
+    private static final Set<String> KEY_SET = new HashSet<>(Arrays.asList(KEYS));
     private static final JsArray KEY_ARRAY = new JsArray(KEYS);
 
     private String urlAndPath;
@@ -106,7 +106,7 @@ public class Request implements ProxyObject {
     private ResourceType resourceType;
     private String resourcePath;
     private String pathParam;
-    private List pathParams = Collections.EMPTY_LIST;
+    private List pathParams = Collections.emptyList();
     private RequestContext requestContext;
 
     public RequestContext getRequestContext() {
@@ -149,7 +149,7 @@ public class Request implements ProxyObject {
     public List<Cookie> getCookies() {
          List<String> cookieValues = getHeaderValues(HttpConstants.HDR_COOKIE);
          if (cookieValues == null) {
-             return Collections.EMPTY_LIST;
+             return Collections.emptyList();
          }
          return cookieValues.stream().map(ClientCookieDecoder.STRICT::decode).collect(toList());
     }
@@ -231,7 +231,7 @@ public class Request implements ProxyObject {
     }
 
     public Map<String, List<String>> getParams() {
-        return params == null ? Collections.EMPTY_MAP : params;
+        return params == null ? Collections.emptyMap() : params;
     }
 
     public void setParams(Map<String, List<String>> params) {
@@ -255,7 +255,7 @@ public class Request implements ProxyObject {
     }
 
     public Map<String, List<String>> getHeaders() {
-        return headers == null ? Collections.EMPTY_MAP : headers;
+        return headers == null ? Collections.emptyMap() : headers;
     }
 
     public void setHeaders(Map<String, List<String>> headers) {
@@ -282,7 +282,7 @@ public class Request implements ProxyObject {
         try {
             return JsValue.fromBytes(body, false, rt);
         } catch (Exception e) {
-            logger.trace("failed to auto-convert response: {}", e);
+            logger.trace("failed to auto-convert response", e);
             return getBodyAsString();
         }
     }
@@ -335,14 +335,14 @@ public class Request implements ProxyObject {
         boolean multipart;
         if (contentType.startsWith("multipart")) {
             multipart = true;
-            multiParts = new HashMap();
+            multiParts = new HashMap<>();
         } else if (contentType.contains("form-urlencoded")) {
             multipart = false;
         } else {
             return;
         }
         logger.trace("decoding content-type: {}", contentType);
-        params = (params == null || params.isEmpty()) ? new HashMap() : new HashMap(params); // since it may be immutable
+        params = (params == null || params.isEmpty()) ? new HashMap<>() : new HashMap<>(params); // since it may be immutable
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), path, Unpooled.wrappedBuffer(body));
         request.headers().add(HttpConstants.HDR_CONTENT_TYPE, contentType);
         InterfaceHttpPostRequestDecoder decoder = multipart ? new HttpPostMultipartRequestDecoder(request) : new HttpPostStandardRequestDecoder(request);
@@ -350,12 +350,8 @@ public class Request implements ProxyObject {
             for (InterfaceHttpData part : decoder.getBodyHttpDatas()) {
                 String name = part.getName();
                 if (multipart && part instanceof FileUpload) {
-                    List<Map<String, Object>> list = multiParts.get(name);
-                    if (list == null) {
-                        list = new ArrayList();
-                        multiParts.put(name, list);
-                    }
-                    Map<String, Object> map = new HashMap();
+                    List<Map<String, Object>> list = multiParts.computeIfAbsent(name, k -> new ArrayList<>());
+                    Map<String, Object> map = new HashMap<>();
                     list.add(map);
                     FileUpload fup = (FileUpload) part;
                     map.put("name", name);
@@ -373,11 +369,7 @@ public class Request implements ProxyObject {
                     }
                 } else { // form-field, url-encoded if not multipart
                     Attribute attribute = (Attribute) part;
-                    List<String> list = params.get(name);
-                    if (list == null) {
-                        list = new ArrayList();
-                        params.put(name, list);
-                    }
+                    List<String> list = params.computeIfAbsent(name, k -> new ArrayList<>());
                     list.add(attribute.getValue());
                 }
             }

--- a/karate-core/src/main/java/com/intuit/karate/http/Response.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Response.java
@@ -160,6 +160,11 @@ public class Response implements ProxyObject {
         return body == null ? null : Json.of(getBodyConverted());
     }
 
+    public boolean isBinary() {
+        ResourceType rt = getResourceType();
+        return rt == null ? false : rt.isBinary();
+    }
+
     public ResourceType getResourceType() {
         if (resourceType == null) {
             String contentType = getContentType();

--- a/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/FeatureRuntimeTest.java
@@ -134,13 +134,13 @@ class FeatureRuntimeTest {
         run("karate-config-getscenario.feature", "classpath:com/intuit/karate/core/");
         System.clearProperty("karate.env");
     }
-    
+
     @Test
     void testKarateJsFromKarateBase() {
         System.setProperty("karate.env", "frombase");
         run("karate-config-frombase.feature", "classpath:com/intuit/karate/core/");
         System.clearProperty("karate.env");
-    }    
+    }
 
     @Test
     void testCallByTag() {
@@ -245,7 +245,7 @@ class FeatureRuntimeTest {
                 .parallel(2);
         assertEquals(0, results.getFailCount());
     }
-    
+
 //    @Test
 //    void testOutlineConfigJsCallOnceParallel() {
 //        Results results = Runner.path("classpath:com/intuit/karate/core/outline-config-js.feature")
@@ -254,7 +254,6 @@ class FeatureRuntimeTest {
 //                .parallel(2);
 //        assertEquals(0, results.getFailCount());
 //    }    
-    
     @Test
     void testOutlineConfigJsCallSingleParallel() {
         Results results = Runner.path("classpath:com/intuit/karate/core/outline-config-js.feature")
@@ -262,17 +261,27 @@ class FeatureRuntimeTest {
                 .karateEnv("callsingle")
                 .parallel(2);
         assertEquals(0, results.getFailCount());
-    }    
+    }
+
+    @Test
+    void testCallSingleOutlineExampleByTag() {
+        Results results = Runner.path("classpath:com/intuit/karate/core/call-single-tag.feature")
+                .configDir("src/test/java/com/intuit/karate/core")
+                .karateEnv("callsingletag")
+                .tags("@runme")
+                .parallel(1);
+        assertEquals(0, results.getFailCount());
+    }
 
     @Test
     void testCallArg() {
         run("call-arg.feature");
     }
-    
+
     @Test
     void testCallArgNull() {
         run("call-arg-null.feature");
-    }    
+    }
 
     @Test
     void testIgnoreStepFailure() {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
@@ -159,7 +159,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello/1'",
+                "path '/hello', '1'",
                 "method get"
         );
         matchVarContains("response", "{ '2': 'bar' }");

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -423,5 +423,18 @@ class KarateMockHandlerTest {
                 "match response == '<http://example.org/#hello> a <http://example.org/#greeting> .'"
         );
     }
+    
+    @Test
+    void testWildcardLikePathMatch() {
+        background().scenario(
+                "requestUri.startsWith('hello/')",
+                "def response = requestUri");
+        run(
+                URL_STEP,
+                "path '/hello/foo/bar'",
+                "method get",
+                "match response == 'hello/foo/bar'"
+        );
+    }    
 
 }

--- a/karate-core/src/test/java/com/intuit/karate/core/call-single-tag-called.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/call-single-tag-called.feature
@@ -1,0 +1,15 @@
+Feature:
+
+Scenario Outline:
+  * print 'in called:', karate.tags
+  * def fromCallSingle = val
+
+  @callme
+  Examples:
+    | val             |
+    | hello world     |
+
+  @dontcallme
+  Examples:
+    | val             |
+    | not hello world |

--- a/karate-core/src/test/java/com/intuit/karate/core/call-single-tag.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/call-single-tag.feature
@@ -1,0 +1,5 @@
+Feature:
+
+@runme
+Scenario:
+* match fromCallSingle == 'hello world'

--- a/karate-core/src/test/java/com/intuit/karate/core/karate-config-callsingletag.js
+++ b/karate-core/src/test/java/com/intuit/karate/core/karate-config-callsingletag.js
@@ -1,0 +1,4 @@
+function fn() {
+  var config = karate.callSingle('call-single-tag-called.feature@callme')
+  return config;
+}

--- a/karate-core/src/test/java/com/intuit/karate/core/parallel/Hello.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/parallel/Hello.java
@@ -1,0 +1,13 @@
+package com.intuit.karate.core.parallel;
+
+/**
+ *
+ * @author pthomas3
+ */
+public class Hello {
+
+    public static String sayHello(String message) {
+        return "hello " + message;
+    }
+
+}

--- a/karate-core/src/test/java/com/intuit/karate/core/parallel/call-single-from-config.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/parallel/call-single-from-config.feature
@@ -8,3 +8,4 @@ Scenario:
 * match response == { message: 'from config' }
 
 * def functionFromCallSingleFromConfig = function(){ return 'resultFromFunctionFromCallSingleFromConfig' }
+* def Hello = Java.type('com.intuit.karate.core.parallel.Hello')

--- a/karate-core/src/test/java/com/intuit/karate/core/parallel/karate-config.js
+++ b/karate-core/src/test/java/com/intuit/karate/core/parallel/karate-config.js
@@ -5,6 +5,8 @@ function fn() {
   };  
   var result = karate.callSingle('call-single-from-config.feature', config);
   config.message = result.response.message;
+  // this will throw the [Multi threaded access requested by thread xxx but is not allowed for language(s) js.] error
+  // config.Hello = result.Hello;
   var result2 = karate.callSingle('call-single-from-config2.feature', result);
   config.message2 = result2.message;  
   return config;

--- a/karate-core/src/test/resources/readme.txt
+++ b/karate-core/src/test/resources/readme.txt
@@ -32,4 +32,4 @@ mvn clean install -P pre-release -DskipTests
 docker tag karate-chrome ptrthomas/karate-chrome:latest
 docker tag karate-chrome ptrthomas/karate-chrome:@@@
 
-docker push ptrthomas/karate-chrome
+docker push ptrthomas/karate-chrome:@@@

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     
     <artifactId>karate-demo</artifactId>

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -18,14 +18,19 @@
 
     <!-- you will not need all these dependencies for a typical karate project !-->
     <!-- for a skeleton project, use the archetype: https://github.com/intuit/karate#quickstart !-->
-    <dependencies>        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-dependencies</artifactId>
-            <version>${spring.boot.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>        
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
@@ -175,7 +180,7 @@
                                 <include>demo/DemoTestParallel.java</include>
                             </includes>
                             <!-- needed for jacoco to integrate properly -->
-                            <argLine>${argLine}</argLine>
+                            <argLine>-Dfile.encoding=UTF-8 ${argLine}</argLine>
                         </configuration>
                     </plugin>                     
                     <plugin>

--- a/karate-demo/src/test/java/demo/DemoTestParallel.java
+++ b/karate-demo/src/test/java/demo/DemoTestParallel.java
@@ -27,9 +27,9 @@ public class DemoTestParallel {
     
     @Test
     public void testParallel() {
-        System.setProperty("karate.env", "demo"); // ensure reset if other tests (e.g. mock) had set env in CI
         Results results = Runner.path("classpath:demo")
                 .outputCucumberJson(true)
+                .karateEnv("demo")
                 .tags("~@ignore").parallel(5);
         generateReport(results.getReportDir());
         assertTrue(results.getErrorMessages(), results.getFailCount() == 0);        

--- a/karate-demo/src/test/java/demo/encoding/encoding.feature
+++ b/karate-demo/src/test/java/demo/encoding/encoding.feature
@@ -21,10 +21,38 @@ Scenario: question mark in the url
     Then status 200
     And match response == 'hello'
 
-Scenario: manually decode before passing to karate
-    * def encoded = 'encoding%2Ffoo%2Bbar'
-    * def decoded = java.net.URLDecoder.decode(encoded, 'UTF-8')
+Scenario: append trailing / to url
     Given url demoBaseUrl
+    And path 'encoding', 'hello', ''
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: path escapes special characters
+    Given url demoBaseUrl
+    And path 'encoding', '"<>#{}|\^[]`'
+    When method get
+    Then status 200
+    And match response == '"<>#{}|\^[]`'
+
+Scenario: leading / in first path is tolerated, but will issue a warning
+    Given url demoBaseUrl + '/'
+    And path '/encoding', 'hello'
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: leading / in path is not required
+    Given url demoBaseUrl
+    And path 'encoding', 'hello'
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: manually decode before passing to karate
+    * def encoded = '%2Ffoo%2Bbar'
+    * def decoded = java.net.URLDecoder.decode(encoded, 'UTF-8')
+    Given url demoBaseUrl + '/encoding'
     And path decoded
     When method get
     Then status 200

--- a/karate-demo/src/test/java/driver/demo/Demo01JavaRunner.java
+++ b/karate-demo/src/test/java/driver/demo/Demo01JavaRunner.java
@@ -37,7 +37,7 @@ public class Demo01JavaRunner {
         driver.quit();
     }
 
-    @Test
+    // @Test
     public void testEdge() throws Exception {
         EdgeChromium driver = EdgeChromium.start();
         driver.setUrl("https://github.com/login");

--- a/karate-e2e-tests/pom.xml
+++ b/karate-e2e-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-e2e-tests</artifactId>
     <packaging>jar</packaging>

--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-gatling</artifactId>
     <packaging>jar</packaging>

--- a/karate-junit4/pom.xml
+++ b/karate-junit4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-junit4</artifactId>
     <packaging>jar</packaging>   

--- a/karate-junit5/pom.xml
+++ b/karate-junit5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-junit5</artifactId>
     <packaging>jar</packaging>

--- a/karate-mock-servlet/pom.xml
+++ b/karate-mock-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     
     <artifactId>karate-mock-servlet</artifactId>

--- a/karate-netty/README.md
+++ b/karate-netty/README.md
@@ -476,20 +476,6 @@ You can use these in the "request matcher" described above. This is how you can 
 
 > The [`pathParams`](#pathparams) is a special case. For each request, it will be initialized only if, and after you have used [`pathMatches()`](#pathmatches). In other words you have to call `pathMatches()` first - typically in the "request matcher" and then you will be able to unpack URL parameters in the `Scenario` body.
 
-## Scenario selection
-When multiple scenarios match request, scenario match score is used to pick first with highest score.
-If multiple scenarios have the same score, then the first one is picked. 
-Scenario match score is based on (from most to least important):
-* `path` match score - using [JAX-RS](org.glassfish.jersey.uri.UriTemplate.COMPARATOR)
-   1. Number of literal characters
-   2. Number of path params without regex (i.e. regex missing)
-   3. Number of path params with explicit regex
-* `method` match
-* `query` parameter match(es)
-* `header` match(es) (this includes `Accept` and `Content-Type` functions) 
-
-*Where multiple files are provided they are evaluated in supplied order*
-
 ## `request`
 This variable holds the value of the request body. It will be a JSON or XML object if it can be parsed as such. Else it would be a string.
 
@@ -500,7 +486,7 @@ Rarely used, unless you are expecting incoming binary content. This variable hol
 Holds the value of the "base URL". This will be in the form `http://somehost:8080` and will include the port number if needed. It may start with `https` if applicable.
 
 ## `requestUri`
-Everything on the right side of the "base URL" (see above). This will include everything, including query string parameters if present. For example if the request URL was `http://foo/bar?baz=ban` the value of `requestUri` will be `/bar?baz=ban`.
+Everything on the right side of the "base URL" (see above). This will include everything, including query string parameters if present. For example if the request URL was `http://foo/bar?baz=ban` the value of `requestUri` will be `bar?baz=ban`.
 
 ## `requestMethod`
 The HTTP method, for e.g. `GET`. It will be in capital letters. Instead of doing things like: `requestMethod == 'GET'` - "best practice" is to use the [`methodIs()`](#methodis) helper function for request matching.
@@ -526,7 +512,12 @@ Helper function that makes it easy to match a URI pattern as well as set [path p
 Scenario: pathMatches('/v1/cats/{id}')
     * def id = pathParams.id
 ```
-This functionality is implemented using [JAX-RS specification](https://docs.oracle.com/cd/E19798-01/821-1841/6nmq2cp26/index.html).
+
+The curly-braces can match only one "segment" of the path at any time. But you can pull off any kind of complicated match using plain old JavaScript and inspecting the other objects such as [`requestUri`](#requesturi). For example, to match *any* path that starts with `/foo/` such as `/foo/bar` and `/foo/bar/baz`:
+
+```cucumber
+Scenario: requestUri.startsWith('foo/')
+```
 
 ## `pathParams`
 JSON variable (not a function) allowing you to extract values by name. See [`pathMatches()`](#pathmatches) above.

--- a/karate-robot/pom.xml
+++ b/karate-robot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.intuit.karate</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>karate-robot</artifactId>
     <packaging>jar</packaging>  

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.intuit.karate</groupId>
     <artifactId>karate-parent</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     
     <name>${project.artifactId}</name>


### PR DESCRIPTION
HttpRequestBuilder.java
- replaced armeria QueryParamsBuilder with apache http URIBuilder.
- minor generics cleanup
- introduced support for fragments.
- URIBuilder now handles path segment encoding, query parameters and any fragment.
- care was taken to ensure that path's prefixed with / are accepted, but a warning is printed letting people know they should remove the prefixing /

encoding.feature
- added more demo/test cases for path encoding

HttpUtils.java
- minor generics cleanup
- final is redundant on static methods

karate-demo/pom.xml
- scope = import only works in the dependencyManagement section, this fixes the maven warning.

Request.java
- minor generics cleanup
- use computeIfAbsent()

HttpClientFactory.java
- public static final are redundant on interface fields
- also use method reference

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
