### PR TITLE
Introduce path encoding (fixes #1561)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,17 +1589,23 @@ Given url 'https://' + e2eHostName + '/v1/api'
 If you are trying to build dynamic URLs including query-string parameters in the form: `http://myhost/some/path?foo=bar&search=true` - please refer to the [`param`](#param) keyword.
 
 ## `path`
-REST-style path parameters.  Can be expressions that will be evaluated.  Comma delimited values are supported which can be more convenient, and takes care of URL-encoding and appending '/' where needed.
+REST-style path parameters.  Can be expressions that will be evaluated.  Comma delimited values are supported which can be more convenient, and takes care of URL-encoding and appending '/' between path segments as needed.
 ```cucumber
+# this is invalid and will result in / being encoded as %2F when sent to the remote server
+# eg. given a documentId of 1234 the path will be: /documents%2F1234%2Fdownload
 Given path 'documents/' + documentId + '/download'
 
-# this is equivalent to the above
+# this is the correct way to specify multiple paths
 Given path 'documents', documentId, 'download'
 
 # or you can do the same on multiple lines if you wish
 Given path 'documents'
 And path documentId
 And path 'download'
+
+# you can also ensure that the constructed url has a trailing / by appending an empty path segment
+# eg. given a documentId of 1234 the path will be: /documents/1234/download/
+Given path 'documents', documentId, 'download', ''
 ```
 Note that the `path` 'resets' after any HTTP request is made but not the `url`. The [Hello World](#hello-world) is a great example of 'REST-ful' use of the `url` when the test focuses on a single REST 'resource'. Look at how the `path` did not need to be specified for the second HTTP `get` call since `/cats` is part of the `url`.
 
@@ -1820,7 +1826,7 @@ Use this for multipart content items that don't have field-names.  Here below is
 also demonstrates using the [`multipart/related`](https://tools.ietf.org/html/rfc2387) content-type.
 
 ```cucumber
-Given path '/v2/documents'
+Given path 'v2', 'documents'
 And multipart entity read('foo.json')
 And multipart field image = read('bar.jpg')
 And header Content-Type = 'multipart/related'

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpClientFactory.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpClientFactory.java
@@ -34,6 +34,6 @@ public interface HttpClientFactory {
 
     HttpClient create(ScenarioEngine engine);
 
-    public static final HttpClientFactory DEFAULT = engine -> new ApacheHttpClient(engine);
+    HttpClientFactory DEFAULT = ApacheHttpClient::new;
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -28,11 +28,11 @@ import com.intuit.karate.StringUtils;
 import com.intuit.karate.graal.JsArray;
 import com.intuit.karate.graal.JsValue;
 import com.intuit.karate.graal.Methods;
-import com.linecorp.armeria.common.QueryParams;
-import com.linecorp.armeria.common.QueryParamsBuilder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +47,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyObject;
 import org.slf4j.Logger;
@@ -84,13 +86,14 @@ public class HttpRequestBuilder implements ProxyObject {
         URL, METHOD, PATH, PARAM, PARAMS, HEADER, HEADERS, BODY, INVOKE,
         GET, POST, PUT, DELETE, PATCH, HEAD, CONNECT, OPTIONS, TRACE
     };
-    private static final Set<String> KEY_SET = new HashSet(Arrays.asList(KEYS));
+    private static final Set<String> KEY_SET = new HashSet<>(Arrays.asList(KEYS));
     private static final JsArray KEY_ARRAY = new JsArray(KEYS);
 
     private String url;
     private String method;
     private List<String> paths;
     private Map<String, List<String>> params;
+    private String fragment;
     private Map<String, List<String>> headers;
     private MultiPartBuilder multiPart;
     private Object body;
@@ -159,14 +162,7 @@ public class HttpRequestBuilder implements ProxyObject {
             }
             multiPart = null;
         }
-        String urlAndPath = getUrlAndPath();
-        if (params != null) {
-            QueryParamsBuilder qpb = QueryParams.builder();
-            params.forEach((k, v) -> qpb.add(k, v));
-            String append = urlAndPath.indexOf('?') == -1 ? "?" : "&";
-            urlAndPath = urlAndPath + append + qpb.toQueryString();
-        }
-        request.setUrl(urlAndPath);
+        request.setUrl(getUri().toASCIIString());
         if (multiPart != null) {
             if (body == null) { // this is not-null only for a re-try, don't rebuild multi-part
                 body = multiPart.build();
@@ -183,7 +179,7 @@ public class HttpRequestBuilder implements ProxyObject {
             request.setBodyForDisplay(multiPart.getBodyForDisplay());
         }
         if (cookies != null && !cookies.isEmpty()) {
-            List<String> cookieValues = new ArrayList(cookies.size());
+            List<String> cookieValues = new ArrayList<>(cookies.size());
             for (Cookie c : cookies) {
                 String cookieValue = ClientCookieEncoder.LAX.encode(c);
                 cookieValues.add(cookieValue);
@@ -245,6 +241,11 @@ public class HttpRequestBuilder implements ProxyObject {
         return this;
     }
 
+    public HttpRequestBuilder fragment(String fragment) {
+        this.fragment = fragment;
+        return this;
+    }
+
     public HttpRequestBuilder paths(String... paths) {
         for (String path : paths) {
             path(path);
@@ -263,32 +264,39 @@ public class HttpRequestBuilder implements ProxyObject {
         return this;
     }
 
-    private String getPath() {
-        String temp = "";
+    private List<String> backwardsCompatiblePaths() {
         if (paths == null) {
-            return temp;
+            return Collections.emptyList();
         }
-        for (String path : paths) {
-            if (path.startsWith("/")) {
+
+        List<String> result = new ArrayList<>(paths.size());
+        for (int i = 0; i < paths.size(); i++) {
+            String path = paths.get(i);
+            if (i == 0 && path.startsWith("/")) {
                 path = path.substring(1);
+                logger.warn("the first path segment starts with a '/', this will be stripped off for now, but in the future this may be escaped and cause your request to fail.");
             }
-            if (!temp.isEmpty() && !temp.endsWith("/")) {
-                temp = temp + "/";
-            }
-            temp = temp + path;
+            result.add(path);
         }
-        return temp;
+        return result;
     }
 
-    public String getUrlAndPath() {
-        if (url == null) {
-            url = "";
+    private URI getUri() {
+        try {
+            URIBuilder builder = url == null ? new URIBuilder() : new URIBuilder(url);
+            if (params != null) {
+                params.forEach((key, values) -> values.forEach(value -> builder.addParameter(key, value)));
+            }
+            // merge paths from the base url with additional paths supplied to this builder
+            List<String> merged = Stream.of(builder.getPathSegments(), backwardsCompatiblePaths())
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            return builder.setPathSegments(merged)
+                    .setFragment(fragment)
+                    .build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
-        String path = getPath();
-        if (path.isEmpty()) {
-            return url;
-        }
-        return url.endsWith("/") ? url + path : url + "/" + path;
     }
 
     public HttpRequestBuilder body(Object body) {
@@ -331,7 +339,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder header(String name, List<String> values) {
         if (headers == null) {
-            headers = new LinkedHashMap();
+            headers = new LinkedHashMap<>();
         }
         for (String key : headers.keySet()) {
             if (key.equalsIgnoreCase(name)) {
@@ -390,7 +398,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder param(String name, List<String> values) {
         if (params == null) {
-            params = new HashMap();
+            params = new HashMap<>();
         }
         List<String> notNullValues = values.stream().filter(v -> v != null).collect(Collectors.toList());
         if (!notNullValues.isEmpty()) {
@@ -417,7 +425,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder cookie(Cookie cookie) {
         if (cookies == null) {
-            cookies = new HashSet();
+            cookies = new HashSet<>();
         }
         cookies.add(cookie);
         return this;
@@ -451,7 +459,7 @@ public class HttpRequestBuilder implements ProxyObject {
     //
     private final Methods.FunVar PATH_FUNCTION = args -> {
         if (args.length == 0) {
-            return getPath();
+            return getUri().getPath();
         } else {
             for (Object o : args) {
                 if (o != null) {
@@ -596,7 +604,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     @Override
     public String toString() {
-        return getUrlAndPath();
+        return getUri().toASCIIString();
     }
 
 }

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpUtils.java
@@ -64,7 +64,7 @@ public class HttpUtils {
         if (count <= 1) {
             return null;
         }
-        Map<String, String> map = new LinkedHashMap(count - 1);
+        Map<String, String> map = new LinkedHashMap<>(count - 1);
         for (int i = 1; i < count; i++) {
             String item = items.get(i);
             int pos = item.indexOf('=');
@@ -90,7 +90,7 @@ public class HttpUtils {
         if (rightSize != leftSize) {
             return null;
         }
-        Map<String, String> map = new LinkedHashMap(leftSize);
+        Map<String, String> map = new LinkedHashMap<>(leftSize);
         for (int i = 0; i < leftSize; i++) {
             String left = leftList.get(i);
             String right = rightList.get(i);
@@ -107,7 +107,7 @@ public class HttpUtils {
         return map;
     }
 
-    public static final String normaliseUriPath(String uri) {
+    public static String normaliseUriPath(String uri) {
         uri = uri.indexOf('?') == -1 ? uri : uri.substring(0, uri.indexOf('?'));
         if (uri.endsWith("/")) {
             uri = uri.substring(0, uri.length() - 1);
@@ -224,7 +224,7 @@ public class HttpUtils {
 
     private static final HttpResponseStatus CONNECTION_ESTABLISHED = new HttpResponseStatus(200, "Connection established");
 
-    public static final FullHttpResponse connectionEstablished() {
+    public static FullHttpResponse connectionEstablished() {
         return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, CONNECTION_ESTABLISHED);
     }
 
@@ -243,7 +243,7 @@ public class HttpUtils {
         List<String> list;
         if (msg.headers().contains(HttpHeaderNames.VIA)) {
             List<String> existing = msg.headers().getAll(HttpHeaderNames.VIA);
-            list = new ArrayList(existing);
+            list = new ArrayList<>(existing);
             list.add(sb.toString());
         } else {
             list = Collections.singletonList(sb.toString());

--- a/karate-core/src/main/java/com/intuit/karate/http/Request.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Request.java
@@ -92,7 +92,7 @@ public class Request implements ProxyObject {
         PATH, METHOD, PARAM, PARAMS, HEADER, HEADERS, PATH_PARAM, PATH_PARAMS, BODY, MULTI_PART, MULTI_PARTS, JSON, AJAX,
         GET, POST, PUT, DELETE, PATCH, HEAD, CONNECT, OPTIONS, TRACE
     };
-    private static final Set<String> KEY_SET = new HashSet(Arrays.asList(KEYS));
+    private static final Set<String> KEY_SET = new HashSet<>(Arrays.asList(KEYS));
     private static final JsArray KEY_ARRAY = new JsArray(KEYS);
 
     private String urlAndPath;
@@ -106,7 +106,7 @@ public class Request implements ProxyObject {
     private ResourceType resourceType;
     private String resourcePath;
     private String pathParam;
-    private List pathParams = Collections.EMPTY_LIST;
+    private List pathParams = Collections.emptyList();
     private RequestContext requestContext;
 
     public RequestContext getRequestContext() {
@@ -149,7 +149,7 @@ public class Request implements ProxyObject {
     public List<Cookie> getCookies() {
          List<String> cookieValues = getHeaderValues(HttpConstants.HDR_COOKIE);
          if (cookieValues == null) {
-             return Collections.EMPTY_LIST;
+             return Collections.emptyList();
          }
          return cookieValues.stream().map(ClientCookieDecoder.STRICT::decode).collect(toList());
     }
@@ -231,7 +231,7 @@ public class Request implements ProxyObject {
     }
 
     public Map<String, List<String>> getParams() {
-        return params == null ? Collections.EMPTY_MAP : params;
+        return params == null ? Collections.emptyMap() : params;
     }
 
     public void setParams(Map<String, List<String>> params) {
@@ -255,7 +255,7 @@ public class Request implements ProxyObject {
     }
 
     public Map<String, List<String>> getHeaders() {
-        return headers == null ? Collections.EMPTY_MAP : headers;
+        return headers == null ? Collections.emptyMap() : headers;
     }
 
     public void setHeaders(Map<String, List<String>> headers) {
@@ -282,7 +282,7 @@ public class Request implements ProxyObject {
         try {
             return JsValue.fromBytes(body, false, rt);
         } catch (Exception e) {
-            logger.trace("failed to auto-convert response: {}", e);
+            logger.trace("failed to auto-convert response", e);
             return getBodyAsString();
         }
     }
@@ -335,14 +335,14 @@ public class Request implements ProxyObject {
         boolean multipart;
         if (contentType.startsWith("multipart")) {
             multipart = true;
-            multiParts = new HashMap();
+            multiParts = new HashMap<>();
         } else if (contentType.contains("form-urlencoded")) {
             multipart = false;
         } else {
             return;
         }
         logger.trace("decoding content-type: {}", contentType);
-        params = (params == null || params.isEmpty()) ? new HashMap() : new HashMap(params); // since it may be immutable
+        params = (params == null || params.isEmpty()) ? new HashMap<>() : new HashMap<>(params); // since it may be immutable
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), path, Unpooled.wrappedBuffer(body));
         request.headers().add(HttpConstants.HDR_CONTENT_TYPE, contentType);
         InterfaceHttpPostRequestDecoder decoder = multipart ? new HttpPostMultipartRequestDecoder(request) : new HttpPostStandardRequestDecoder(request);
@@ -350,12 +350,8 @@ public class Request implements ProxyObject {
             for (InterfaceHttpData part : decoder.getBodyHttpDatas()) {
                 String name = part.getName();
                 if (multipart && part instanceof FileUpload) {
-                    List<Map<String, Object>> list = multiParts.get(name);
-                    if (list == null) {
-                        list = new ArrayList();
-                        multiParts.put(name, list);
-                    }
-                    Map<String, Object> map = new HashMap();
+                    List<Map<String, Object>> list = multiParts.computeIfAbsent(name, k -> new ArrayList<>());
+                    Map<String, Object> map = new HashMap<>();
                     list.add(map);
                     FileUpload fup = (FileUpload) part;
                     map.put("name", name);
@@ -373,11 +369,7 @@ public class Request implements ProxyObject {
                     }
                 } else { // form-field, url-encoded if not multipart
                     Attribute attribute = (Attribute) part;
-                    List<String> list = params.get(name);
-                    if (list == null) {
-                        list = new ArrayList();
-                        params.put(name, list);
-                    }
+                    List<String> list = params.computeIfAbsent(name, k -> new ArrayList<>());
                     list.add(attribute.getValue());
                 }
             }

--- a/karate-core/src/main/java/com/intuit/karate/http/Request.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/Request.java
@@ -178,17 +178,8 @@ public class Request implements ProxyObject {
         StringUtils.Pair pair = HttpUtils.parseUriIntoUrlBaseAndPath(url);
         urlBase = pair.left;
         QueryStringDecoder qsd = new QueryStringDecoder(pair.right);
-        String path = qsd.path();
-        Map<String, List<String>> queryParams = qsd.parameters();
-        if (queryParams.size() == 1) {
-            List<String> list = queryParams.values().iterator().next();
-            if (!list.isEmpty() && "".equals(list.get(0))) {
-                // annoying edge case where url had encoded characters
-                path = pair.right.replace('?', '�');
-            }
-        }
-        setPath(path);
-        setParams(queryParams);
+        setPath(qsd.path());
+        setParams(qsd.parameters());
     }
 
     public String getUrlAndPath() {

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
@@ -68,7 +68,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "hello world");
@@ -82,7 +82,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "cookie foo = 'bar'",
                 "method get"
         );
@@ -97,7 +97,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "cookie foo = { value: 'bar', samesite: 'Strict', secure: true }",
                 "method get"
         );
@@ -112,7 +112,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVarContains("responseHeaders", "{ set-cookie: ['foo=bar; expires=Wed, 30-Dec-20 09:25:45 GMT; path=/; domain=.example.com; HttpOnly; SameSite=Lax; Secure'] }");
@@ -126,7 +126,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "header Content-Type = 'application/xxx.pingixxxxxx.checkUsernamePassword+json'",
                 "method post"
         );
@@ -142,7 +142,7 @@ class KarateHttpMockHandlerTest {
         run(
                 urlStep(),
                 "configure headers = function(request){ return { 'api-key': request.bodyAsString } }",
-                "path '/hello'",
+                "path 'hello'",
                 "request 'some text'",
                 "method post"
         );
@@ -159,7 +159,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello', '1'",
+                "path 'hello', '1'",
                 "method get"
         );
         matchVarContains("response", "{ '2': 'bar' }");
@@ -173,7 +173,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "header Transfer-Encoding = 'chunked'",
                 "request { foo: 'bar' }",
                 "method post"
@@ -189,7 +189,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match response == '{ \"id\" \"123\" }'",
                 "match responseType == 'string'"
@@ -210,7 +210,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/first'",
+                "path 'first'",
                 "form fields { username: 'blah', password: 'blah' }",
                 "method post"
         );

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateHttpMockHandlerTest.java
@@ -159,7 +159,7 @@ class KarateHttpMockHandlerTest {
         startMockServer();
         run(
                 urlStep(),
-                "path '/hello/1'",
+                "path '/hello', '1'",
                 "method get"
         );
         matchVarContains("response", "{ '2': 'bar' }");

--- a/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/KarateMockHandlerTest.java
@@ -52,7 +52,7 @@ class KarateMockHandlerTest {
                 "def response = 'hello world'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "hello world");
@@ -65,7 +65,7 @@ class KarateMockHandlerTest {
                 "def response = requestHeaders");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "request { foo: 'bar' }",
                 "method post"
         );
@@ -94,7 +94,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "param foo = 'bar'",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ foo: ['bar'] }");
@@ -108,7 +108,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "params { foo: 'bar' }",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ foo: ['bar'] }");
@@ -122,7 +122,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "param foo = 'bar,baz'",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ foo: ['bar,baz'] }");
@@ -136,7 +136,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "param foo = ['bar', 'baz']",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ foo: ['bar', 'baz'] }");
@@ -149,7 +149,7 @@ class KarateMockHandlerTest {
                 "def response = requestHeaders");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "header foo = 'bar'",
                 "method get"
         );
@@ -163,7 +163,7 @@ class KarateMockHandlerTest {
                 "def response = requestHeaders");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "def fun = function(arg){ return [arg.first, arg.second] }",
                 "header Authorization = call fun { first: 'foo', second: 'bar' }",
                 "method get"
@@ -178,7 +178,7 @@ class KarateMockHandlerTest {
                 "def response = requestHeaders");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "request { foo: 'bar' }",
                 "method post"
         );
@@ -193,7 +193,7 @@ class KarateMockHandlerTest {
                 "def response = '{ \"foo\": \"bar\"}'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match responseHeaders == { 'Content-Type': ['application/json'] }",
                 "match header content-type == 'application/json'",
@@ -209,7 +209,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "cookie foo = 'bar'",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ Cookie: ['foo=bar'] }");
@@ -226,7 +226,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "cookie foo = {value:'bar', expires: '" + pastDate + "'}",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ Cookie: ['foo=bar'] }");
@@ -243,7 +243,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "cookie foo = { value: 'bar', expires: '" + futureDate + "' }",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ Cookie: ['foo=bar'] }");
@@ -257,7 +257,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "cookie foo = { value: 'bar', max-age: '0' }",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ Cookie: ['#string'] }");
@@ -271,7 +271,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "form field foo = 'bar'",
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("response", "{ foo: ['bar'] }");
@@ -285,7 +285,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "form field foo = 'bar'",
-                "path '/hello'",
+                "path 'hello'",
                 "method post"
         );
         matchVar("response", "foo=bar");
@@ -299,7 +299,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "multipart field foo = 'bar'",
-                "path '/hello'",
+                "path 'hello'",
                 "method post"
         );
         matchVar("response", "{ foo: ['bar'] }");
@@ -313,7 +313,7 @@ class KarateMockHandlerTest {
         run(
                 URL_STEP,
                 "multipart file foo = { filename: 'foo.txt', value: 'hello' }",
-                "path '/hello'",
+                "path 'hello'",
                 "method post"
         );
         matchVar("response", "{ foo: [{ name: 'foo', value: '#notnull', contentType: 'text/plain', charset: 'UTF-8', filename: 'foo.txt', transferEncoding: '7bit' }] }");
@@ -327,7 +327,7 @@ class KarateMockHandlerTest {
                         "def response = ''");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("responseHeaders", "{ 'Content-Type': ['text/html'] }");
@@ -342,7 +342,7 @@ class KarateMockHandlerTest {
         run(
                 "configure lowerCaseResponseHeaders = true",
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get"
         );
         matchVar("responseHeaders", "{ 'content-type': ['text/html'] }");
@@ -356,7 +356,7 @@ class KarateMockHandlerTest {
                 "def response = '<hello>world</hello>'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match header content-type == 'application/xml'",
                 "match responseType == 'xml'",
@@ -371,7 +371,7 @@ class KarateMockHandlerTest {
                 "def response = '<hello>world</hello>'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match header content-type == 'text/plain'",
                 "match responseType == 'xml'",
@@ -386,7 +386,7 @@ class KarateMockHandlerTest {
                 "def response = '{ \"foo\": \"bar\"}'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match header content-type == 'text/plain'",
                 "match responseType == 'json'",
@@ -401,7 +401,7 @@ class KarateMockHandlerTest {
                 "def response = '<http://example.org/#hello> a <http://example.org/#greeting> .'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match header content-type == 'text/plain'",
                 "match responseType == 'string'",
@@ -416,7 +416,7 @@ class KarateMockHandlerTest {
                 "def response = '<http://example.org/#hello> a <http://example.org/#greeting> .'");
         run(
                 URL_STEP,
-                "path '/hello'",
+                "path 'hello'",
                 "method get",
                 "match header content-type == 'text/turtle'",
                 "match responseType == 'string'",
@@ -431,7 +431,7 @@ class KarateMockHandlerTest {
                 "def response = requestUri");
         run(
                 URL_STEP,
-                "path '/hello/foo/bar'",
+                "path 'hello', 'foo', 'bar'",
                 "method get",
                 "match response == 'hello/foo/bar'"
         );

--- a/karate-core/src/test/java/com/intuit/karate/http/RequestHandlerTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/RequestHandlerTest.java
@@ -52,7 +52,7 @@ class RequestHandlerTest {
 
     @Test
     void testIndexAndAjaxPost() {
-        request.path("/index");
+        request.path("index");
         handle();
         matchHeaderContains("Set-Cookie", "karate.sid");
         matchHeaderEquals("Content-Type", "text/html");
@@ -61,7 +61,7 @@ class RequestHandlerTest {
         assertTrue(body.contains("<td>Apple</td>"));
         assertTrue(body.contains("<td>Orange</td>"));
         assertTrue(body.contains("<span>Billie</span>"));
-        request.path("/person")
+        request.path("person")
                 .contentType("application/x-www-form-urlencoded")
                 .header("HX-Request", "true")
                 .body("firstName=John&lastName=Smith&email=john%40smith.com")

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -18,14 +18,19 @@
 
     <!-- you will not need all these dependencies for a typical karate project !-->
     <!-- for a skeleton project, use the archetype: https://github.com/intuit/karate#quickstart !-->
-    <dependencies>        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-dependencies</artifactId>
-            <version>${spring.boot.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>        
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
@@ -175,7 +180,7 @@
                                 <include>demo/DemoTestParallel.java</include>
                             </includes>
                             <!-- needed for jacoco to integrate properly -->
-                            <argLine>${argLine}</argLine>
+                            <argLine>-Dfile.encoding=UTF-8 ${argLine}</argLine>
                         </configuration>
                     </plugin>                     
                     <plugin>

--- a/karate-demo/src/main/java/com/intuit/karate/demo/controller/EncodingController.java
+++ b/karate-demo/src/main/java/com/intuit/karate/demo/controller/EncodingController.java
@@ -23,9 +23,10 @@
  */
 package com.intuit.karate.demo.controller;
 
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  *
@@ -35,14 +36,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/encoding")
 public class EncodingController {
 
-    @RequestMapping("/{token:.+}")
-    public String echoPath(@PathVariable String token) {
-        return token;
+    @RequestMapping("/**")
+    public String echoPath(HttpServletRequest httpServletRequest) {
+        // running from spring boot + tomcat
+        if (httpServletRequest.getPathInfo() == null) {
+            return httpServletRequest.getServletPath().replace("/encoding/", "");
+
+        // running from mock spring mvc
+        } else {
+            return httpServletRequest.getPathInfo().replace("/encoding/", "");
+        }
     }
     
-    @RequestMapping("/index.php?/api/v2/{token:.+}")
-    public String echoPathWithQuestion(@PathVariable String token) {
-        return token;
+    @RequestMapping("/index.php?/api/v2/**")
+    public String echoPathWithQuestion(HttpServletRequest httpServletRequest) {
+        // running from spring boot + tomcat
+        if (httpServletRequest.getPathInfo() == null) {
+            return httpServletRequest.getServletPath().replace("/encoding/index.php?/api/v2/", "");
+
+        // running from mock spring mvc
+        } else {
+            return httpServletRequest.getPathInfo().replace("/encoding/index.php?/api/v2/", "");
+        }
     }    
 
 }

--- a/karate-demo/src/test/java/demo/DemoTestParallel.java
+++ b/karate-demo/src/test/java/demo/DemoTestParallel.java
@@ -37,7 +37,7 @@ public class DemoTestParallel {
     
     public static void generateReport(String karateOutputPath) {        
         Collection<File> jsonFiles = FileUtils.listFiles(new File(karateOutputPath), new String[] {"json"}, true);
-        List<String> jsonPaths = new ArrayList(jsonFiles.size());
+        List<String> jsonPaths = new ArrayList<>(jsonFiles.size());
         jsonFiles.forEach(file -> jsonPaths.add(file.getAbsolutePath()));
         Configuration config = new Configuration(new File("target"), "demo");
         ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);

--- a/karate-demo/src/test/java/demo/encoding/encoding.feature
+++ b/karate-demo/src/test/java/demo/encoding/encoding.feature
@@ -26,7 +26,7 @@ Scenario: append trailing / to url
     And path 'encoding', 'hello', ''
     When method get
     Then status 200
-    And match response == 'hello'
+    And match response == 'hello/'
 
 Scenario: path escapes special characters
     Given url demoBaseUrl

--- a/karate-demo/src/test/java/demo/encoding/encoding.feature
+++ b/karate-demo/src/test/java/demo/encoding/encoding.feature
@@ -21,10 +21,38 @@ Scenario: question mark in the url
     Then status 200
     And match response == 'hello'
 
-Scenario: manually decode before passing to karate
-    * def encoded = 'encoding%2Ffoo%2Bbar'
-    * def decoded = java.net.URLDecoder.decode(encoded, 'UTF-8')
+Scenario: append trailing / to url
     Given url demoBaseUrl
+    And path 'encoding', 'hello', ''
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: path escapes special characters
+    Given url demoBaseUrl
+    And path 'encoding', '"<>#{}|\^[]`'
+    When method get
+    Then status 200
+    And match response == '"<>#{}|\^[]`'
+
+Scenario: leading / in first path is tolerated, but will issue a warning
+    Given url demoBaseUrl + '/'
+    And path '/encoding', 'hello'
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: leading / in path is not required
+    Given url demoBaseUrl
+    And path 'encoding', 'hello'
+    When method get
+    Then status 200
+    And match response == 'hello'
+
+Scenario: manually decode before passing to karate
+    * def encoded = '%2Ffoo%2Bbar'
+    * def decoded = java.net.URLDecoder.decode(encoded, 'UTF-8')
+    Given url demoBaseUrl + '/encoding'
     And path decoded
     When method get
     Then status 200

--- a/karate-demo/src/test/java/demo/encoding/encoding.feature
+++ b/karate-demo/src/test/java/demo/encoding/encoding.feature
@@ -35,13 +35,6 @@ Scenario: path escapes special characters
     Then status 200
     And match response == '"<>#{}|\^[]`'
 
-Scenario: leading / in first path is tolerated, but will issue a warning
-    Given url demoBaseUrl + '/'
-    And path '/encoding', 'hello'
-    When method get
-    Then status 200
-    And match response == 'hello'
-
 Scenario: leading / in path is not required
     Given url demoBaseUrl
     And path 'encoding', 'hello'
@@ -50,7 +43,7 @@ Scenario: leading / in path is not required
     And match response == 'hello'
 
 Scenario: manually decode before passing to karate
-    * def encoded = '%2Ffoo%2Bbar'
+    * def encoded = 'foo%2Bbar'
     * def decoded = java.net.URLDecoder.decode(encoded, 'UTF-8')
     Given url demoBaseUrl + '/encoding'
     And path decoded

--- a/karate-demo/src/test/java/demo/error/no-url.feature
+++ b/karate-demo/src/test/java/demo/error/no-url.feature
@@ -1,11 +1,11 @@
-Feature:  No URLfound proper error response
+Feature:  No URL found proper error response
 
   Background:
     * url demoBaseUrl
     * configure lowerCaseResponseHeaders = true
 
   Scenario: Invalid URL response
-    Given path '/hello'
+    Given path 'hello'
     When method get
     Then status 404
     And match header content-type contains 'application/json'


### PR DESCRIPTION
HttpRequestBuilder.java
- replaced armeria QueryParamsBuilder with apache http URIBuilder.
- minor generics cleanup
- introduced support for fragments.
- URIBuilder now handles path segment encoding, query parameters and any fragment.
- care was taken to ensure that path's prefixed with / are accepted, but a warning is printed letting people know they should remove the prefixing /

encoding.feature
- added more demo/test cases for path encoding

HttpUtils.java
- minor generics cleanup
- final is redundant on static methods

karate-demo/pom.xml
- scope = import only works in the dependencyManagement section, this fixes the maven warning.

Request.java
- minor generics cleanup
- use computeIfAbsent()

HttpClientFactory.java
- public static final are redundant on interface fields
- also use method reference

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : #1561
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation
