### PR TITLE
Add support for sharing karate variables across gatling scenarios as is.

### DIFF
--- a/karate-gatling/README.md
+++ b/karate-gatling/README.md
@@ -227,6 +227,8 @@ val create = scenario("create").exec(karateFeature("classpath:mock/cats-create.f
 
 Here above, the variable `id` that was defined (using `def`) in the [Karate feature](src/test/scala/mock/cats-create.feature) - is being retrieved on the Gatling side using the Scala API.
 
+On the karate side, after scenario involving a [`karateFeature()`](#karatefeature) completes, the variables  are passed onto [`karateFeature()`](#karatefeature) invocations as indicated in the [simulation example](src/test/scala/mock/CatsCreateReadSimulation.scala) - in the read `id` from the one defined post create.
+
 ### Gatling Session
 The [Gatling session](https://gatling.io/docs/current/session/session_api/) attributes and `userId` would be available in a Karate variable under the name-space `__gatling`. So you can refer to the user-id for the thread as follows:
 

--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -77,6 +77,7 @@
                 <configuration>
                     <disableCompiler>true</disableCompiler>
                     <skip>${skipTests}</skip>
+                    <runMultipleSimulations>true</runMultipleSimulations>
                 </configuration>
                 <executions>
                     <execution>

--- a/karate-gatling/src/test/scala/mock/CatsCreateReadSimulation.scala
+++ b/karate-gatling/src/test/scala/mock/CatsCreateReadSimulation.scala
@@ -1,0 +1,41 @@
+package mock
+
+import com.intuit.karate.gatling.PreDef._
+import io.gatling.core.Predef._
+
+import scala.concurrent.duration._
+
+class CatsCreateReadSimulation extends Simulation {
+
+  MockUtils.startServer(0)
+
+  val protocol = karateProtocol(
+    "/cats/{id}" -> Nil,
+    "/cats" -> pauseFor("get" -> 15, "post" -> 25)
+  )
+
+  protocol.nameResolver = (req, ctx) => req.getHeader("karate-name")
+
+  val createOnly = scenario("create").exec(karateFeature("classpath:mock/cats-cr.feature@name=create")).exec(session => {
+    println("*** session status in gatling: " + session.status)
+    println("*** session in gatling create: " + session)
+    session
+  })
+
+  val readOnly = scenario("read").exec(karateFeature("classpath:mock/cats-cr.feature@name=read")).exec(session => {
+    println("*** id in gatling: " + session("id").as[String])
+    println("*** session status in gatling: " + session.status)
+    println("*** session in gatling during read: " + session)
+    session
+  })
+
+  val createAndRead = scenario("createAndRead").group("createAndRead") {
+    exec(createOnly).exec(readOnly)
+  }
+
+
+  setUp(
+    createAndRead.inject(rampUsers(10) during (5 seconds)).protocols(protocol)
+  ).assertions(details("createAndRead").failedRequests.percent.is(0))
+
+}

--- a/karate-gatling/src/test/scala/mock/cats-cr.feature
+++ b/karate-gatling/src/test/scala/mock/cats-cr.feature
@@ -1,0 +1,23 @@
+Feature: cats crud
+
+  Background:
+    * url baseUrl
+    * print 'gatling userId:', __gatling.userId
+
+  @name=create
+  Scenario: create
+
+    Given request { name: 'Billie' }
+    When method post
+    Then status 200
+    And match response == { id: '#uuid', name: 'Billie' }
+    * def id = response.id
+
+  @name=read
+  Scenario: read
+    # requires id to be passed.
+    Given path id
+    When method get
+    Then status 200
+    And match response == { id: '#(id)', name: 'Billie' }
+


### PR DESCRIPTION
### Description

Currently, while using karate-gatling, there is no way to pass variables from one karate feature to another.
This implies that today, a new feature would have to be written for performance tests and the power of gatling cannot be fully utilised.

In this PR, by introducing `__karate` as temporary key in gatling session to carry over the variables post result of one karateFeature execution onto another.

- Relevant Issues : https://github.com/intuit/karate/issues/1612
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
