### PR TITLE
feat: added comments in Cucumber JSON result file

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/StepResult.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/StepResult.java
@@ -187,6 +187,9 @@ public class StepResult {
             }
             map.put("embeddings", embedList);
         }
+        if (step.getComments() != null && !step.getComments().isEmpty()) {
+            map.put("comments", step.getComments());
+        }
         return map;
     }
 

--- a/karate-core/src/test/java/com/intuit/karate/core/feature-result-cucumber.json
+++ b/karate-core/src/test/java/com/intuit/karate/core/feature-result-cucumber.json
@@ -49,12 +49,16 @@
                         ]
                     },
                     "keyword": "*",
-                    "line": 10,
+                    "line": 12,
                     "doc_string": {
                         "content_type": "",
                         "value": "#string",
-                        "line": 10
-                    }
+                        "line": 12
+                    },
+                    "comments": [
+                        "# Some comments",
+                        "# Some more comments"
+                    ]
                 },
                 {
                     "name": "call read('feature-result-called.feature')",
@@ -68,7 +72,7 @@
                         ]
                     },
                     "keyword": "*",
-                    "line": 11
+                    "line": 13
                 },
                 {
                     "name": "com\/intuit\/karate\/core\/feature-result-called.feature",
@@ -82,7 +86,7 @@
                         ]
                     },
                     "keyword": "",
-                    "line": 11
+                    "line": 13
                 },
                 {
                     "name": "print 'in called'",
@@ -154,11 +158,11 @@
                         ]
                     },
                     "keyword": "*",
-                    "line": 12,
+                    "line": 14,
                     "doc_string": {
                         "content_type": "",
                         "value": "#string",
-                        "line": 12
+                        "line": 14
                     }
                 }
             ],
@@ -202,7 +206,7 @@
             ]
         },
         {
-            "line": 19,
+            "line": 21,
             "name": "hello foo",
             "description": "",
             "id": "hello-foo",
@@ -221,11 +225,11 @@
                         ]
                     },
                     "keyword": "*",
-                    "line": 15,
+                    "line": 17,
                     "doc_string": {
                         "content_type": "",
                         "value": "#string",
-                        "line": 15
+                        "line": 17
                     }
                 }
             ],
@@ -265,7 +269,7 @@
             ]
         },
         {
-            "line": 20,
+            "line": 22,
             "name": "hello bar",
             "description": "",
             "id": "hello-bar",
@@ -284,11 +288,11 @@
                         ]
                     },
                     "keyword": "*",
-                    "line": 15,
+                    "line": 17,
                     "doc_string": {
                         "content_type": "",
                         "value": "#string",
-                        "line": 15
+                        "line": 17
                     }
                 }
             ],

--- a/karate-core/src/test/java/com/intuit/karate/core/feature-result.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/feature-result.feature
@@ -7,6 +7,8 @@ Background:
 
 @two
 Scenario: hello world
+# Some comments
+# Some more comments
 * print 'before'
 * call read('feature-result-called.feature')
 * print 'after'

--- a/karate-core/src/test/java/com/intuit/karate/core/feature-result.json
+++ b/karate-core/src/test/java/com/intuit/karate/core/feature-result.json
@@ -24,7 +24,11 @@
                         "status": "passed"
                     },
                     "step": {
-                        "line": 10,
+                        "comments": [
+                            "# Some comments",
+                            "# Some more comments"
+                        ],
+                        "line": 12,
                         "prefix": "*",
                         "index": 0,
                         "text": "print 'before'"
@@ -38,7 +42,7 @@
                         "status": "passed"
                     },
                     "step": {
-                        "line": 11,
+                        "line": 13,
                         "prefix": "*",
                         "index": 1,
                         "text": "call read('feature-result-called.feature')"
@@ -131,7 +135,7 @@
                         "status": "passed"
                     },
                     "step": {
-                        "line": 12,
+                        "line": 14,
                         "prefix": "*",
                         "index": 2,
                         "text": "print 'after'"
@@ -153,7 +157,7 @@
             "tags": [
                 "one",
                 "two"
-            ]            
+            ]
         },
         {
             "stepResults": [
@@ -179,7 +183,7 @@
                         "status": "passed"
                     },
                     "step": {
-                        "line": 15,
+                        "line": 17,
                         "prefix": "*",
                         "index": 0,
                         "text": "print 'name:', name"
@@ -190,12 +194,12 @@
             "executorName": "main",
             "name": "hello foo",
             "description": "",
-            "line": 19,
+            "line": 21,
             "sectionIndex": 1,
             "startTime": "#number",
             "endTime": "#number",
             "exampleIndex": 0,
-            "refId": "[2.1:19]",
+            "refId": "[2.1:21]",
             "durationMillis": "#number",
             "failed": false,
             "tags": [
@@ -229,7 +233,7 @@
                         "status": "passed"
                     },
                     "step": {
-                        "line": 15,
+                        "line": 17,
                         "prefix": "*",
                         "index": 0,
                         "text": "print 'name:', name"
@@ -240,12 +244,12 @@
             "executorName": "#string",
             "name": "hello bar",
             "description": "",
-            "line": 20,
+            "line": 22,
             "sectionIndex": 1,
             "startTime": "#number",
             "endTime": "#number",
             "exampleIndex": 1,
-            "refId": "[2.2:20]",
+            "refId": "[2.2:22]",
             "durationMillis": "#number",
             "failed": false,
             "tags": [
@@ -253,7 +257,7 @@
             ],
             "exampleData": {
                 "name": "bar"
-            }            
+            }
         }
     ],
     "prefixedPath": "classpath:com\/intuit\/karate\/core\/feature-result.feature",


### PR DESCRIPTION
### Description

This PR fixes #1677 by  adding step comments in the Cucumber JSON result files, similar to what is done for the Karate JSON result files.
This will allow to get comments in the Cucumber report generated by cucumber-reporting. See damianszczepanik/cucumber-reporting#828


- Relevant Issues : #1677 
- Type of change :
  - [x ] Addition or Improvement of documentation
