### PR TITLE
Support parsing valid HTML5 responses

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <antlr.version>4.9.2</antlr.version>
         <graal.version>21.2.0</graal.version>
-        <jsoup.version>1.11.3</jsoup.version>
+        <jsoup.version>1.13.1</jsoup.version>
     </properties>
 
     <dependencies>

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <antlr.version>4.9.2</antlr.version>
         <graal.version>21.2.0</graal.version>
+        <jsoup.version>1.11.3</jsoup.version>
     </properties>
 
     <dependencies>
@@ -118,6 +119,11 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
         </dependency>
     </dependencies>
 

--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -129,13 +129,7 @@ public class XmlUtils {
             builder.setEntityResolver(dtdEntityResolver);
             org.jsoup.nodes.Document jsoupDoc = Jsoup.parse(html);
             Document doc = new W3CDom().fromJsoup(jsoupDoc);
-            if (dtdEntityResolver.dtdPresent) { // DOCTYPE present
-                // the XML was not parsed, but I think it hangs at the root as a text node
-                // so conversion to string and back has the effect of discarding the DOCTYPE !
-                return toXmlDoc(toString(doc, false));
-            } else {
-                return doc;
-            }
+            return doc;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/XmlUtils.java
@@ -27,10 +27,6 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import org.jsoup.Jsoup;
 import org.jsoup.helper.W3CDom;
-import org.w3c.dom.*;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html-test.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html-test.feature
@@ -1,10 +1,7 @@
 Feature:
 
-  Background:
-     * def port = karate.start('parse-html.feature').port
-
   Scenario: post redirect to get
-
+    * def port = karate.start('parse-html.feature').port
     * def loginUrl = 'http://localhost:' + port + '/login'
 
     Given url loginUrl

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html-test.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html-test.feature
@@ -1,0 +1,13 @@
+Feature:
+
+  Background:
+     * def port = karate.start('parse-html.feature').port
+
+  Scenario: post redirect to get
+
+    * def loginUrl = 'http://localhost:' + port + '/login'
+
+    Given url loginUrl
+    And request {}
+    When method POST
+    Then status 200

--- a/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/mock/parse-html.feature
@@ -1,0 +1,29 @@
+Feature: simple mock
+
+  Scenario: pathMatches('/login') && methodIs('post')
+    * def responseStatus = 302
+    * def responseHeaders = { 'Location': '../login/' }
+    * def response =
+      """
+      <!DOCTYPE HTML>
+      <title>Redirecting...</title>
+      <h1>Redirecting...</h1>
+      <p>You should be redirected automatically to target URL: <a href="/">/</a>.  If not click the link.
+      """
+
+  Scenario: pathMatches('/login') && methodIs('get')
+    * def response =
+    """
+    <!DOCTYPE html>
+    <html lang="en-US">
+        <head>
+            <title>Hello world</title>
+            <!-- unquoted attribute conforms to spec https://html.spec.whatwg.org/#unquoted -->
+            <script nonce=abc123 type="text/javascript">
+            </script>
+        </head>
+        <body>
+         <h1>Hello</h1>
+        </body>
+    </html>
+    """


### PR DESCRIPTION
### Description

Bug fix for parsing valid html5 responses.
Caused valid html5 mocks to fail as well as causing sso calls to fail since karate 1
Tests for mock which were failing not passing included

- Relevant Issues : https://github.com/intuit/karate/issues/1684
- Relevant PRs : 
- Type of change :
  - [ ] New feature
  - [ X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

#### Reservations:
* added jsoup as library
* exception control flow, but may be best minimal workaround
* not sure how better to do minimal change since strings are being passed around without mime context

#### Rationale:
* assuming XML content type based on string starting with '<' is not valid 
* afaik SAXParser only handles XML so will not be able to handle HTML


#### Details:
Logging code flow for valid html response caused non-xml but valid html response to fail on 
* mocks (since karate 0.9)
* http responses from my sso provider (since karate 1).

Was able to duplicate mock flow in included unit tests. 
SSO response flow was duplicated locally by directly instantiating com.intuit.karate.http.ApacheHttpClient
 with stack trace:
```
org.graalvm.polyglot.PolyglotException: org.xml.sax.SAXParseException; lineNumber: 25; columnNumber: 3; The element type "meta" must be terminated by the matching end-tag "</meta>".
- com.intuit.karate.XmlUtils.toXmlDoc(XmlUtils.java:138)
- com.intuit.karate.graal.JsValue.fromString(JsValue.java:281)
- com.intuit.karate.graal.JsValue.fromBytes(JsValue.java:264)
- com.intuit.karate.http.HttpLogger.logBody(HttpLogger.java:73)
- com.intuit.karate.http.HttpLogger.logResponse(HttpLogger.java:149)
- com.intuit.karate.http.ApacheHttpClient.invoke(ApacheHttpClient.java:317)
```
