### PR TITLE
Do not display the skipped feature in IDE Test Runner 

### DIFF
--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -26,6 +26,11 @@ package com.intuit.karate.junit5;
 import com.intuit.karate.Runner;
 import com.intuit.karate.Suite;
 import com.intuit.karate.core.Feature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,12 +39,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
-import com.intuit.karate.core.FeatureRuntime;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DynamicContainer;
-import org.junit.jupiter.api.DynamicNode;
-import org.junit.jupiter.api.TestFactory;
 
 public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNode> {
 

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import com.intuit.karate.core.FeatureRuntime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
@@ -60,6 +61,8 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
         List<DynamicNode> list = new ArrayList();
         List<CompletableFuture> futures = new ArrayList();
         for (Feature feature : suite.features) {
+            if (!FeatureRuntime.of(suite, feature).scenarios.hasNext()) // if there is no scenarios selected for execution, skip the feature
+                continue;
             FeatureNode featureNode = new FeatureNode(suite, futures, feature, suite.tagSelector);
             String testName = feature.getResource().getFileNameWithoutExtension();
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -61,9 +61,9 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
         List<DynamicNode> list = new ArrayList();
         List<CompletableFuture> futures = new ArrayList();
         for (Feature feature : suite.features) {
-            if (!FeatureRuntime.of(suite, feature).scenarios.hasNext()) // if there is no scenarios selected for execution, skip the feature
-                continue;
             FeatureNode featureNode = new FeatureNode(suite, futures, feature, suite.tagSelector);
+            if (!featureNode.hasNext()) // if no scenarios to execute, just skip the feature
+                continue;
             String testName = feature.getResource().getFileNameWithoutExtension();
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);
             list.add(node);

--- a/karate-junit5/src/test/java/karate/SampleTest.java
+++ b/karate-junit5/src/test/java/karate/SampleTest.java
@@ -8,28 +8,33 @@ class SampleTest {
     Karate testSample() {
         return Karate.run("sample").relativeTo(getClass());
     }
-    
+
     @Karate.Test
     Karate testTags() {
         return Karate.run("tags").tags("@second").relativeTo(getClass());
     }
 
     @Karate.Test
+    Karate testTagsWithoutFeatureName() {
+        return Karate.run().tags("@second").relativeTo(getClass());
+    }
+
+    @Karate.Test
     Karate testFullPath() {
         return Karate.run("classpath:karate/tags.feature").tags("@first");
     }
-    
+
     @Karate.Test
     Karate testSystemProperty() {
         return Karate.run("classpath:karate/tags.feature")
                 .tags("@second")
                 .karateEnv("e2e")
                 .systemProperty("foo", "bar");
-    }    
-    
+    }
+
     @Karate.Test
     Karate testAll() {
         return Karate.run().relativeTo(getClass());
-    }    
+    }
 
 }


### PR DESCRIPTION

### Description
 When you execute tests providing the tag selector, the skipped features are also displayed in the list of features in Test Runner in IntelliJ. When you have a long list of feature files it does create a confusion.
This fix avoid adding features to list which do not have any scenarios to be executed.

- Relevant Issues : #1712 
- Type of change :
  -  Bug fix for existing feature
