### PR TITLE
Fix inefficient map iteration

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/StringUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/StringUtils.java
@@ -239,9 +239,10 @@ public class StringUtils {
         if (map == null || name == null) {
             return null;
         }
-        for (String key : map.keySet()) {
+        for (Map.Entry<String, T> entry : map.entrySet()) {
+            String key = entry.getKey();
             if (name.equalsIgnoreCase(key)) {
-                return map.get(key);
+                return entry.getValue();
             }
         }
         return null;

--- a/karate-core/src/main/java/com/intuit/karate/driver/playwright/PlaywrightDriver.java
+++ b/karate-core/src/main/java/com/intuit/karate/driver/playwright/PlaywrightDriver.java
@@ -568,8 +568,9 @@ public class PlaywrightDriver implements Driver {
         if (titleOrUrl == null) {
             return;
         }
-        for (String pageGuid : pageFrames.keySet()) {
-            String frameGuid = pageFrames.get(pageGuid).iterator().next();
+        for (Map.Entry<String, Set<String>> entry : pageFrames.entrySet()) {
+            String pageGuid = entry.getKey();
+            String frameGuid = entry.getValue().iterator().next();
             String title = evalFrame(frameGuid, "document.title").getResultValue();
             if (title != null && title.contains(titleOrUrl)) {
                 currentPage = pageGuid;

--- a/karate-demo/src/test/java/demo/oauth/Signer.java
+++ b/karate-demo/src/test/java/demo/oauth/Signer.java
@@ -39,11 +39,12 @@ public class Signer {
 public static void sign(String token, Map<String, String> params) {
         List<String> list = new ArrayList();
         String tokenClientSlat = "";
-        for (String key : params.keySet()) {
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String key = entry.getKey();
             if (key.equals("token_client_salt")) {
-                tokenClientSlat = params.get(key);
+                tokenClientSlat = entry.getValue();
             }
-            String paramString = key + "=" + params.get(key);
+            String paramString = key + "=" + entry.getValue();
             list.add(paramString);
         }
         Collections.sort(list);


### PR DESCRIPTION
Iterate over `Map#entrySet` instead of `Map#keySet` when value is needed.

- Relevant Issues : #1727
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

This patch was generated automatically using [Logifix](https://github.com/lyxell/logifix) as part of a research project.