### PR TITLE
Evaluate @ignore tags case insensitively

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/StringUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/StringUtils.java
@@ -260,6 +260,15 @@ public class StringUtils {
         }
     }
 
+    public static boolean containsIgnoreKeyCase(List<String> list, String str) {
+        for (String i : list) {
+            if (i.equalsIgnoreCase(str)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static String throwableToString(Throwable t) {
         try(final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw, true)) {

--- a/karate-core/src/main/java/com/intuit/karate/StringUtils.java
+++ b/karate-core/src/main/java/com/intuit/karate/StringUtils.java
@@ -260,7 +260,7 @@ public class StringUtils {
         }
     }
 
-    public static boolean containsIgnoreKeyCase(List<String> list, String str) {
+    public static boolean containsIgnoreCase(List<String> list, String str) {
         for (String i : list) {
             if (i.equalsIgnoreCase(str)) {
                 return true;

--- a/karate-core/src/main/java/com/intuit/karate/core/Tags.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Tags.java
@@ -132,7 +132,7 @@ public class Tags implements Iterable<Tag> {
     }
 
     public boolean evaluate(String tagSelector, String karateEnv) {
-        if (tags.contains(Tag.IGNORE)) {
+        if (StringUtils.containsIgnoreKeyCase(tags, Tag.IGNORE)) {
             return false;
         }
         Values envValues = valuesFor(Tag.ENV);

--- a/karate-core/src/main/java/com/intuit/karate/core/Tags.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Tags.java
@@ -132,7 +132,7 @@ public class Tags implements Iterable<Tag> {
     }
 
     public boolean evaluate(String tagSelector, String karateEnv) {
-        if (StringUtils.containsIgnoreKeyCase(tags, Tag.IGNORE)) {
+        if (StringUtils.containsIgnoreCase(tags, Tag.IGNORE)) {
             return false;
         }
         Values envValues = valuesFor(Tag.ENV);

--- a/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/StringUtilsTest.java
@@ -131,4 +131,12 @@ class StringUtilsTest {
                 StringUtils.wrappedLinesEstimate("", 2));
     }
 
+    @Test
+    void testContainsIgnoreCase() {
+        List<String> list = Arrays.asList("foo", "bar");
+        assertTrue(StringUtils.containsIgnoreCase(list, "foo"));
+        assertTrue(StringUtils.containsIgnoreCase(list, "Foo"));
+        assertFalse(StringUtils.containsIgnoreCase(list, "baz"));
+    }
+
 }


### PR DESCRIPTION
### Description

This simple PR allows for case-insensitive evaluation of the built-in `@ignore` tag. We use camel-cased annotations everywhere else so it would be nice if we didn't have to remember this exception.

If you're interested in merging this but feel tests would be appropriate then I am happy to add those - it just seemed like probable overkill.

Thanks for your consideration and for your work on Karate.

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
